### PR TITLE
Integrate "/auth" API endpoint with frontend sign-in flow #4

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,6 +1,5 @@
 # Privy Configuration
-NEXT_PUBLIC_PRIVY_APP_ID=your-privy-app-id
+NEXT-PUBLIC_PRIVY_APP_ID=your-privy-app-id
 
-# Google AI API Key (for Genkit)
-GOOGLE_AI_API_KEY=your-google-ai-api-key
-
+# Base API URL
+NEXT_PUBLIC_API_BASE_URL=your-api-base-url

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,117 @@
+// API utility functions for authenticated requests
+
+const API_KEY_STORAGE_KEY = 'gatewayz_api_key';
+const USER_DATA_STORAGE_KEY = 'gatewayz_user_data';
+
+export interface AuthResponse {
+  success: boolean;
+  message: string;
+  user_id: number;
+  api_key: string;
+  auth_method: string;
+  privy_user_id: string;
+  is_new_user: boolean;
+  display_name: string;
+  email: string;
+  credits: number;
+  timestamp: string | null;
+}
+
+export interface UserData {
+  user_id: number;
+  api_key: string;
+  auth_method: string;
+  privy_user_id: string;
+  display_name: string;
+  email: string;
+  credits: number;
+}
+
+// API Key Management
+export const saveApiKey = (apiKey: string): void => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(API_KEY_STORAGE_KEY, apiKey);
+  }
+};
+
+export const getApiKey = (): string | null => {
+  if (typeof window !== 'undefined') {
+    return localStorage.getItem(API_KEY_STORAGE_KEY);
+  }
+  return null;
+};
+
+export const removeApiKey = (): void => {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem(API_KEY_STORAGE_KEY);
+    localStorage.removeItem(USER_DATA_STORAGE_KEY);
+  }
+};
+
+// User Data Management
+export const saveUserData = (userData: UserData): void => {
+  if (typeof window !== 'undefined') {
+    localStorage.setItem(USER_DATA_STORAGE_KEY, JSON.stringify(userData));
+  }
+};
+
+export const getUserData = (): UserData | null => {
+  if (typeof window !== 'undefined') {
+    const data = localStorage.getItem(USER_DATA_STORAGE_KEY);
+    return data ? JSON.parse(data) : null;
+  }
+  return null;
+};
+
+// Authenticated API Request Helper
+export const makeAuthenticatedRequest = async (
+  endpoint: string,
+  options: RequestInit = {}
+): Promise<Response> => {
+  const apiKey = getApiKey();
+  
+  if (!apiKey) {
+    throw new Error('No API key found. User must be authenticated.');
+  }
+
+  const defaultHeaders = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${apiKey}`,
+  };
+
+  const requestOptions: RequestInit = {
+    ...options,
+    headers: {
+      ...defaultHeaders,
+      ...options.headers,
+    },
+  };
+
+  return fetch(endpoint, requestOptions);
+};
+
+// Process authentication response
+export const processAuthResponse = (response: AuthResponse): void => {
+  if (response.success && response.api_key) {
+    saveApiKey(response.api_key);
+    
+    const userData: UserData = {
+      user_id: response.user_id,
+      api_key: response.api_key,
+      auth_method: response.auth_method,
+      privy_user_id: response.privy_user_id,
+      display_name: response.display_name,
+      email: response.email,
+      credits: response.credits,
+    };
+    
+    saveUserData(userData);
+    
+    console.log('User authenticated successfully:', {
+      user_id: response.user_id,
+      display_name: response.display_name,
+      credits: response.credits,
+      is_new_user: response.is_new_user
+    });
+  }
+};

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,2 @@
+// API configuration
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://127.0.0.1:8000';

--- a/src/lib/privy.ts
+++ b/src/lib/privy.ts
@@ -3,7 +3,6 @@ import { PrivyProvider } from '@privy-io/react-auth';
 export const privyConfig = {
   appId: process.env.NEXT_PUBLIC_PRIVY_APP_ID!,
   config: {
-    // Customize the appearance of the Privy modal
     appearance: {
       theme: 'light',
       accentColor: '#000000',
@@ -11,14 +10,6 @@ export const privyConfig = {
     },
     // Configure login methods
     loginMethods: ['email', 'google', 'github'],
-    // // Configure embedded wallets (disabled for now as requested)
-    // embeddedWallets: {
-    //   createOnLogin: 'off',
-    // },
-    // Configure OAuth providers
-    oauth: {
-      providers: ['google', 'github'],
-    },
   },
 };
 


### PR DESCRIPTION
**Summary:**
This PR integrates the `/auth` API endpoint into the frontend sign-in process. Users now receive an API key upon signing in, which is stored in `localStorage` and used for subsequent backend API requests.

**Details:**
* Integrated `/auth` endpoint with frontend sign-in.
* API key is securely stored in `localStorage` for reuse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic sign-in to the backend when logged in, with API key and user info securely stored for seamless authenticated requests.
  - Centralized API base URL configuration for client-side requests.

- Bug Fixes
  - Improved error handling during authentication; automatically logs out and clears credentials on failure.

- Documentation
  - Updated environment variables: added API base URL; removed deprecated Google AI key; renamed Privy App ID variable.

- Chores
  - Cleaned up unused commented configuration in authentication provider setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->