### PR TITLE
fix(chat): stop labeling 403 as "session expired" (re-login loop)

### DIFF
--- a/src/app/api/chat/completions/__tests__/error-handling.test.ts
+++ b/src/app/api/chat/completions/__tests__/error-handling.test.ts
@@ -223,6 +223,35 @@ describe('Chat Completions API - Error Handling', () => {
         })
       );
     });
+
+    it('should treat 403 as an authorization error, NOT an expired session', async () => {
+      mockFetch.mockResolvedValueOnce(
+        createMockResponse(403, 'Forbidden', { detail: 'Active subscription required' })
+      );
+
+      const request = new NextRequest('http://localhost:3000/api/chat/completions', {
+        method: 'POST',
+        body: JSON.stringify({
+          model: 'openai/gpt-4',
+          messages: [{ role: 'user', content: 'Test' }],
+          stream: false,
+        }),
+        headers: {
+          'content-type': 'application/json',
+          'authorization': 'Bearer valid-key',
+        },
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      // A 403 means the key is valid but lacks access/subscription — NOT an expired session.
+      // Telling the user to "log out and log back in" sends them into a pointless re-login loop.
+      expect(data.type).toBe('authorization_error');
+      expect(data.message).not.toContain('session has expired');
+      expect(data.message.toLowerCase()).toMatch(/access|subscription|upgrade|credits/);
+    });
   });
 
   describe('5xx Server Errors', () => {

--- a/src/app/api/chat/completions/route.ts
+++ b/src/app/api/chat/completions/route.ts
@@ -524,8 +524,17 @@ export async function POST(request: NextRequest) {
             let errorType = 'api_error';
 
             if (response.status === 401 || response.status === 403) {
-              userMessage = 'Your session has expired. Please log out and log back in to continue. If this issue persists, clear your browser cookies and log in again.';
-              errorType = 'auth_error';
+              if (response.status === 403) {
+                // 403 = the API key is valid but lacks access/subscription for this action.
+                // This is NOT an expired session — telling the user to log out and back in
+                // sends them into a pointless re-login loop that can never resolve a billing
+                // or access problem. Point them at credits/upgrade instead.
+                userMessage = "You don't have access to this model or action. If this is a paid model, add credits or upgrade your plan, then try again.";
+                errorType = 'authorization_error';
+              } else {
+                userMessage = 'Your session has expired. Please log out and log back in to continue. If this issue persists, clear your browser cookies and log in again.';
+                errorType = 'auth_error';
+              }
 
               // Capture auth errors to Sentry
               Sentry.captureException(
@@ -867,8 +876,15 @@ export async function POST(request: NextRequest) {
           }
         );
       } else if (httpError.status === 401 || httpError.status === 403) {
-        userMessage = 'Your session has expired. Please log out and log back in to continue. If this issue persists, clear your browser cookies and log in again.';
-        errorType = 'auth_error';
+        if (httpError.status === 403) {
+          // 403 = valid key, but no access/subscription for this action. Not an expired
+          // session — route the user to credits/upgrade rather than a re-login loop.
+          userMessage = "You don't have access to this model or action. If this is a paid model, add credits or upgrade your plan, then try again.";
+          errorType = 'authorization_error';
+        } else {
+          userMessage = 'Your session has expired. Please log out and log back in to continue. If this issue persists, clear your browser cookies and log in again.';
+          errorType = 'auth_error';
+        }
 
         Sentry.captureException(
           new Error(`Chat auth error: ${httpError.status} ${httpError.statusText}`),

--- a/src/lib/__tests__/streaming-comprehensive.test.ts
+++ b/src/lib/__tests__/streaming-comprehensive.test.ts
@@ -762,7 +762,7 @@ describe('Streaming - Comprehensive Tests', () => {
       ).rejects.toThrow(/Trial credits have been used up.*FREE models/);
     });
 
-    test('should handle 403 forbidden with helpful message', async () => {
+    test('should handle 403 forbidden as an access error, not an expired session', async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         status: 403,
@@ -770,11 +770,14 @@ describe('Streaming - Comprehensive Tests', () => {
         json: async () => ({ detail: 'Access forbidden' }),
       });
 
+      // 403 = valid key but no access/subscription. It must point the user at
+      // credits/upgrade, NOT tell them their session expired (which would send them
+      // into a pointless re-login loop that can never resolve a billing problem).
       await expect(
         collectChunks(
           streamChatResponse('/api/chat/completions', 'test-key', { model: 'gpt-4', messages: [], stream: true })
         )
-      ).rejects.toThrow(/session has expired.*log out and log back in/i);
+      ).rejects.toThrow(/access|subscription|upgrade|credits/i);
     });
 
     test('should handle 404 model not found', async () => {

--- a/src/lib/streaming.ts
+++ b/src/lib/streaming.ts
@@ -314,16 +314,16 @@ export async function* streamChatResponse(
       );
     }
 
-    // Handle 403 Forbidden - invalid or expired API key
+    // Handle 403 Forbidden - valid key, but no access/subscription for this action.
+    // NOT an expired session: a re-login loop can never resolve a billing/access problem.
     if (response.status === 403) {
       devError('403 Forbidden details:', errorData);
 
-      // Capture auth error to Sentry
       Sentry.captureException(
-        new Error('Chat 403 Forbidden - session expired'),
+        new Error('Chat 403 Forbidden - access/subscription denied'),
         {
           tags: {
-            error_type: 'chat_auth_error',
+            error_type: 'chat_authorization_error',
             http_status: 403,
             model: String(requestBody.model || 'unknown'),
           },
@@ -336,7 +336,7 @@ export async function* streamChatResponse(
       );
 
       throw new Error(
-        'Your session has expired. Please log out and log back in to continue. If this issue persists, clear your browser cookies and log in again.'
+        "You don't have access to this model or action. If this is a paid model, add credits or upgrade your plan, then try again."
       );
     }
 

--- a/src/lib/streaming/__tests__/stream-chat.test.ts
+++ b/src/lib/streaming/__tests__/stream-chat.test.ts
@@ -262,7 +262,7 @@ describe('streamChatResponse', () => {
       global.window = originalWindow;
     });
 
-    it('should throw AuthenticationError on 403', async () => {
+    it('should throw an access (not session-expired) error on 403', async () => {
       global.fetch = jest.fn().mockResolvedValueOnce({
         ok: false,
         status: 403,
@@ -276,7 +276,19 @@ describe('streamChatResponse', () => {
         { model: 'gpt-4', messages: [] }
       );
 
-      await expect(collectChunks(generator)).rejects.toThrow(AuthenticationError);
+      // 403 = valid key but no access/subscription. It must NOT surface as an expired
+      // session (that sends the user into a pointless re-login loop). It is a plain
+      // StreamingError pointing at access/billing, not an AuthenticationError.
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(StreamingError);
+      expect(thrown).not.toBeInstanceOf(AuthenticationError);
+      expect((thrown as Error).message.toLowerCase()).toMatch(/access|subscription|upgrade|credits/);
+      expect((thrown as Error).message).not.toContain('session has expired');
     });
 
     it('should throw StreamingError on 404 model not found', async () => {

--- a/src/lib/streaming/stream-chat.ts
+++ b/src/lib/streaming/stream-chat.ts
@@ -178,12 +178,13 @@ async function handleHttpError(
     }
 
     case 403:
-      // Capture auth error to Sentry
+      // 403 = the key is valid but lacks access/subscription for this action. This is NOT
+      // an expired session; a re-login loop can never resolve a billing/access problem.
       Sentry.captureException(
-        new Error('Chat 403 Forbidden - session expired'),
+        new Error('Chat 403 Forbidden - access/subscription denied'),
         {
           tags: {
-            error_type: 'chat_auth_error',
+            error_type: 'chat_authorization_error',
             http_status: 403,
             model: String(requestBody.model || 'unknown'),
           },
@@ -194,8 +195,8 @@ async function handleHttpError(
           level: 'warning',
         }
       );
-      throw new AuthenticationError(
-        'Your session has expired. Please log out and log back in to continue. If this issue persists, clear your browser cookies and log in again.'
+      throw new StreamingError(
+        "You don't have access to this model or action. If this is a paid model, add credits or upgrade your plan, then try again."
       );
 
     case 404:


### PR DESCRIPTION
## Problem
Live bug: users reported chat showing **"Your session has expired. Please log out and log back in"** even while signed in with credits — and re-logging in didn't help.

Root cause: the backend returns **403** when a key is valid but lacks access/subscription for a model/action. All three chat error paths conflated **403 with 401** and showed the "session expired" message. That message routed the client into its auth-recovery path (logout → login) — a loop that can never fix a billing/access problem, so chat looked permanently broken.

(Backend was verified healthy: `/v1/chat/completions` returns 200 for a valid key, and guest mode returns 200. This was purely the frontend's error mapping.)

## Fix
Handle 401 and 403 distinctly in:
- `src/app/api/chat/completions/route.ts` — both the streaming and non-streaming error blocks
- `src/lib/streaming.ts` and `src/lib/streaming/stream-chat.ts` — the streamed error bubble

**401** → keeps "session expired" (genuine auth). **403** → a `StreamingError` that points the user at credits/upgrade and is classified as an authorization error (no logout loop).

## Tests
- New: 403 proxy test asserts `type: 'authorization_error'` and no "session expired".
- Updated: `stream-chat` and `streaming-comprehensive` 403 tests to the new access-error contract.
- All three touched suites pass (87/87 in isolation). The repo's pre-existing unrelated suite failures are unchanged (162 on clean master vs 162 here).

## Note
This stops the misleading loop. A deeper follow-up (why some users hold a stale key, and forcing a clean key refresh) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)