### PR TITLE
fix(pricing): wire live Stripe product/price IDs for checkout

### DIFF
--- a/src/lib/pricing-config.ts
+++ b/src/lib/pricing-config.ts
@@ -47,8 +47,9 @@ export const tierConfigs: Record<string, TierConfig> = {
     ],
     ctaText: 'Get Started',
     ctaVariant: 'default',
-    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_STARTER_PRICE_ID,
-    stripeProductId: 'prod_UKdXKZYAH2tsfV',
+    // Live Stripe IDs (price IDs are public, not secrets). Env overrides if set.
+    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_STARTER_PRICE_ID || 'price_1TF2gqLVT8n4vaEn2KV2s8S8',
+    stripeProductId: 'prod_TMVNv05QSJcdXq',
   },
   pro: {
     id: 'pro',
@@ -66,8 +67,8 @@ export const tierConfigs: Record<string, TierConfig> = {
     ],
     ctaText: 'Get Started',
     ctaVariant: 'default',
-    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID,
-    stripeProductId: 'prod_UKdYdR6ZUQY4oV',
+    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_PRO_PRICE_ID || 'price_1SPYv5LVT8n4vaEnEAmeTnX4',
+    stripeProductId: 'prod_TMHUqS0Xs7Vz3Z',
   },
   max: {
     id: 'max',
@@ -86,8 +87,8 @@ export const tierConfigs: Record<string, TierConfig> = {
     ctaText: 'Get Started',
     ctaVariant: 'secondary',
     popular: true,
-    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID,
-    stripeProductId: 'prod_UKdYWnMg2Widfb',
+    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_MAX_PRICE_ID || 'price_1TF2e4LVT8n4vaEnHnW7P2oE',
+    stripeProductId: 'prod_TMHUXL8p0onwwO',
   },
   enterprise: {
     id: 'enterprise',


### PR DESCRIPTION
## Problem
"Get Started" on the pricing page did nothing. The checkout page guards on `currentTier.stripePriceId`, which came only from `NEXT_PUBLIC_STRIPE_*_PRICE_ID` env vars — unset in production — so it was `undefined` and the button no-opped. The hardcoded product IDs were also TEST-mode while prod uses a LIVE Stripe key.

## Fix
Each tier now uses the **live** product ID and falls back to the **live** price ID when the env var is unset (price IDs are public, not secrets; env still overrides).

| Tier | product | price | $/mo |
|---|---|---|---|
| basic | `prod_TMVNv05QSJcdXq` | `price_1TF2gqLVT8n4vaEn2KV2s8S8` | 35 |
| pro | `prod_TMHUqS0Xs7Vz3Z` | `price_1SPYv5LVT8n4vaEnEAmeTnX4` | 120 |
| max | `prod_TMHUXL8p0onwwO` | `price_1TF2e4LVT8n4vaEnHnW7P2oE` | 350 |

The backend `subscription_products` table was updated to the same live product IDs so tier resolution (checkout + webhooks) stays correct.

## Still required (ops, outside this PR)
- **Re-enable the Stripe webhook** (`/api/stripe/webhook`) — Stripe disabled it after repeated failures; paid users won't be credited until it's back on.
- Confirm prod `STRIPE_WEBHOOK_SECRET` is the **live** endpoint's signing secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)