### PR TITLE
chore(types): fix the 6 pre-existing tsc errors blocking Type Check CI

### DIFF
--- a/src/app/api/chat/ai-sdk-completions/route.ts
+++ b/src/app/api/chat/ai-sdk-completions/route.ts
@@ -26,9 +26,9 @@ export async function POST(request: NextRequest) {
         return new Response(
           JSON.stringify({
             error: 'Rate limit exceeded',
-            message: `Guest rate limit reached. Resets ${formatResetTime(rateLimitResult.resetTime)}.`,
+            message: `Guest rate limit reached. Resets ${formatResetTime(rateLimitResult.resetInMs)}.`,
             remaining: rateLimitResult.remaining,
-            resetTime: rateLimitResult.resetTime,
+            resetTime: rateLimitResult.resetInMs,
           }),
           { status: 429, headers: { 'Content-Type': 'application/json' } }
         );

--- a/src/app/models/page.tsx
+++ b/src/app/models/page.tsx
@@ -60,7 +60,6 @@ async function getAllModels(): Promise<UniqueModel[]> {
     Sentry.captureException(error, {
       tags: { component: 'models-page', fallback: 'static' },
       extra: {
-        USE_UNIQUE_MODELS_ENDPOINT,
         NEXT_STATIC_EXPORT: process.env.NEXT_STATIC_EXPORT,
         CI: process.env.CI,
         VERCEL: process.env.VERCEL,

--- a/src/components/chat/model-select.tsx
+++ b/src/components/chat/model-select.tsx
@@ -870,7 +870,7 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
             <span className="mr-1 shrink-0">Sort:</span>
             {(
               [
-                { mode: 'gateway' as const, label: 'Gateway' },
+                { mode: 'gateway' as const, label: 'Gateway', icon: null },
                 { mode: 'az' as const, label: 'A–Z', icon: <ArrowDownAZ className="h-3 w-3" /> },
                 { mode: 'free-first' as const, label: 'Free', icon: <Sparkles className="h-3 w-3" /> },
                 { mode: 'speed' as const, label: 'Speed', icon: <Zap className="h-3 w-3" /> },

--- a/src/components/tier/model-tier-badge.tsx
+++ b/src/components/tier/model-tier-badge.tsx
@@ -30,7 +30,8 @@ export function ModelTierBadge({ requiredTier, showLocked = true }: ModelTierBad
     return null;
   }
 
-  const tierColors = {
+  const tierColors: Record<UserTier, string> = {
+    free: 'bg-slate-100 text-slate-700 border-slate-200',
     basic: 'bg-slate-100 text-slate-700 border-slate-200',
     pro: 'bg-blue-100 text-blue-700 border-blue-200',
     max: 'bg-purple-100 text-purple-700 border-purple-200',

--- a/src/components/tier/tier-info-card.tsx
+++ b/src/components/tier/tier-info-card.tsx
@@ -29,6 +29,7 @@ export function TierInfoCard() {
   }
 
   const tierColors = {
+    free: 'bg-slate-100 text-slate-900',
     basic: 'bg-slate-100 text-slate-900',
     pro: 'bg-blue-100 text-blue-900',
     max: 'bg-purple-100 text-purple-900',


### PR DESCRIPTION
## Summary

The `Type Check` CI job (`tsc --noEmit`) has been failing on `master` with 6 pre-existing type errors, unrelated to feature work. This resolves them. No behavior change.

- **ai-sdk-completions route** — the guest rate-limit result field is `resetInMs`, not `resetTime` (matches `completions/route.ts` and `formatResetTime`'s signature).
- **models/page** — drop the undefined `USE_UNIQUE_MODELS_ENDPOINT` from the Sentry `extra` (it's referenced but never declared).
- **model-select** — give the "Gateway" sort option `icon: null` so the `{ mode, label, icon }` destructure is valid across the union (renders as nothing; UI unchanged).
- **tier badge + info card** — add the `free` tier to `tierColors` so indexing by `UserTier` (`'free'|'basic'|'pro'|'max'`) type-checks; badge map typed as `Record<UserTier, string>`.

`tsc` reports no real errors after this; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)