### PR TITLE
fix(audit): repoint broken catalog endpoints, fix key deletion, fix CI OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
       - name: Build application
         run: pnpm build
         env:
+          # Increase Node.js memory for large Next.js builds
+          NODE_OPTIONS: '--max-old-space-size=8192'
           # Set minimal required env vars for build
           NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID || 'test-privy-app-id' }}
           NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL || 'https://api.gatewayz.ai' }}
@@ -266,6 +268,8 @@ jobs:
       - name: Build application for E2E tests
         run: pnpm build
         env:
+          # Increase Node.js memory for large Next.js builds
+          NODE_OPTIONS: '--max-old-space-size=8192'
           NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID || 'test-privy-app-id' }}
           NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL || 'https://api.gatewayz.ai' }}
           NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || 'pk_test_dummy' }}

--- a/src/app/settings/keys/page.tsx
+++ b/src/app/settings/keys/page.tsx
@@ -430,7 +430,7 @@ export default function ApiKeysPage() {
         `/api/user/api-keys/${keyId}`,
         {
           method: 'DELETE',
-          body: JSON.stringify({ confirmation: "DELETE" }),
+          body: JSON.stringify({ confirmation: "DELETE_KEY" }),
         }
       );
 

--- a/src/lib/catalog-api.ts
+++ b/src/lib/catalog-api.ts
@@ -184,7 +184,7 @@ export class ModelsAPI {
     if (params?.offset) queryParams.append('offset', params.offset.toString());
     if (params?.is_active_only) queryParams.append('is_active_only', 'true');
 
-    const endpoint = `${API_BASE_URL}/models${queryParams.toString() ? `?${queryParams}` : ''}`;
+    const endpoint = `${API_BASE_URL}/catalog/models-db${queryParams.toString() ? `?${queryParams}` : ''}`;
     const response = await makeAuthenticatedRequest(endpoint);
 
     if (!response.ok) {
@@ -195,7 +195,7 @@ export class ModelsAPI {
   }
 
   static async getModelById(modelId: number): Promise<ModelWithProvider> {
-    const response = await makeAuthenticatedRequest(`${API_BASE_URL}/models/${modelId}`);
+    const response = await makeAuthenticatedRequest(`${API_BASE_URL}/catalog/models-db/${modelId}`);
 
     if (!response.ok) {
       throw await parseErrorResponse(response, 'Loading model');
@@ -205,7 +205,7 @@ export class ModelsAPI {
   }
 
   static async getModelsByProvider(providerSlug: string, isActiveOnly: boolean = true): Promise<ModelWithProvider[]> {
-    const endpoint = `${API_BASE_URL}/models/provider/${providerSlug}${isActiveOnly ? '?is_active_only=true' : ''}`;
+    const endpoint = `${API_BASE_URL}/catalog/models-db/provider/${providerSlug}${isActiveOnly ? '?is_active_only=true' : ''}`;
     const response = await makeAuthenticatedRequest(endpoint);
 
     if (!response.ok) {
@@ -217,8 +217,8 @@ export class ModelsAPI {
 
   static async getModelStats(providerId?: number): Promise<ModelStats> {
     const endpoint = providerId
-      ? `${API_BASE_URL}/models/stats?provider_id=${providerId}`
-      : `${API_BASE_URL}/models/stats`;
+      ? `${API_BASE_URL}/catalog/models-db/stats?provider_id=${providerId}`
+      : `${API_BASE_URL}/catalog/models-db/stats`;
     const response = await makeAuthenticatedRequest(endpoint);
 
     if (!response.ok) {
@@ -230,8 +230,8 @@ export class ModelsAPI {
 
   static async searchModels(query: string, providerId?: number): Promise<ModelWithProvider[]> {
     const endpoint = providerId
-      ? `${API_BASE_URL}/models/search?q=${encodeURIComponent(query)}&provider_id=${providerId}`
-      : `${API_BASE_URL}/models/search?q=${encodeURIComponent(query)}`;
+      ? `${API_BASE_URL}/catalog/models-db/search?q=${encodeURIComponent(query)}&provider_id=${providerId}`
+      : `${API_BASE_URL}/catalog/models-db/search?q=${encodeURIComponent(query)}`;
 
     const response = await makeAuthenticatedRequest(endpoint);
 
@@ -244,7 +244,7 @@ export class ModelsAPI {
 
   static async getModelHealthHistory(modelId: number, limit: number = 100): Promise<ModelHealthHistory[]> {
     const response = await makeAuthenticatedRequest(
-      `${API_BASE_URL}/models/${modelId}/health/history?limit=${limit}`
+      `${API_BASE_URL}/catalog/models-db/${modelId}/health/history?limit=${limit}`
     );
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary
Three audit-confirmed bugs, verified not to be false alarms before implementing:

- **`catalog-api.ts` `ModelsAPI`**: 5 of 6 methods called `/models/*`, but the matching backend router is mounted at `/catalog/models-db/*`. The one call that resolved (`getAllModels` via bare `/models`) hit an unrelated flat-catalog endpoint with a mismatched shape. Net effect: the entire `/catalog/models` admin page failed with a visible error banner. Repointed all 6 URLs; TS types already matched the correct router's schemas, so no type changes needed.
- **API key deletion**: `settings/keys/page.tsx` sent `confirmation: "DELETE"`, but the backend requires the exact literal `"DELETE_KEY"` (confirmed via git blame to be the deliberate, established backend contract — predates a later, buggy schema-default change). Every delete attempt was failing with a 400. Fixed the one literal.
- **CI build OOM**: `next build` was crashing with a V8 heap-out-of-memory error in both the `Build` and `E2E Tests` jobs — this also fails identically on `master` right now (pre-existing, not something this PR introduces). Root cause: no `NODE_OPTIONS` heap flag set in `ci.yml`, even though the exact same fix already exists in `desktop-build.yml` (`--max-old-space-size=8192`) — just never copied over. Applied the same fix to both `ci.yml` build steps.

## Test plan
- [x] Full `jest` suite diffed against `master`: identical 25 pre-existing failing suites / 272 failing tests on both; no regressions.
- [x] `tsc --noEmit`: no new errors.
- [x] No existing tests covered the two page-level fixes (delete-key confirmation, ModelsAPI URLs) directly; verified manually against the backend's actual route definitions.
- [x] CI YAML validated with `yaml.safe_load`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for large builds by increasing available Node.js memory during app and end-to-end test builds.
  * Updated API key deletion confirmation so key removal works correctly again.
  * Switched model-related requests to a new backend path, helping model pages and lookups continue to load and search as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->