### PR TITLE
fix(tier/credits): stop misleading cancelled subscribers with a paid badge; preserve fractional credits

### DIFF
--- a/src/components/__tests__/SessionInitializer.test.tsx
+++ b/src/components/__tests__/SessionInitializer.test.tsx
@@ -303,7 +303,7 @@ describe('SessionInitializer', () => {
         expect(api.saveUserData).toHaveBeenCalledWith(
           expect.objectContaining({
             user_id: 12345,
-            credits: 150, // Should be floored
+            credits: 150.75, // Fractional credits preserved (no flooring)
             tier: 'pro', // Should be lowercased
             subscription_status: 'active',
             subscription_end_date: 1735689600,

--- a/src/hooks/__tests__/use-tier.test.ts
+++ b/src/hooks/__tests__/use-tier.test.ts
@@ -525,7 +525,10 @@ describe('useTier', () => {
 
       expect(result.current.hasSubscription).toBe(false);
       expect(result.current.subscriptionStatus).toBe('cancelled');
-      expect(result.current.tier).toBe('basic');
+      // Cancelled subscribers show 'free' even with a stale paid `tier` column and
+      // leftover purchased credits — the purchased-credits override only applies to
+      // webhook-lag statuses (inactive/trial/undefined), not terminal ones like 'cancelled'.
+      expect(result.current.tier).toBe('free');
     });
 
     it('should update when credits change', () => {
@@ -720,7 +723,7 @@ describe('useTier', () => {
       expect(result.current.tierInfo.monthlyPrice).toBe('$8.00');
     });
 
-    it('should support downgrade from max to basic', () => {
+    it('should support downgrade from max to basic (cancelled subscription shows free)', () => {
       // Start as Max user
       const maxUser: UserData = {
         user_id: 123,
@@ -741,7 +744,8 @@ describe('useTier', () => {
       expect(result.current.tier).toBe('max');
       expect(result.current.canAccessModel('max')).toBe(true);
 
-      // Downgrade to Basic
+      // Cancel subscription — backend downgrades the `tier` DB column to 'basic'
+      // without zeroing leftover credits, but the cosmetic tier badge must show 'free'.
       const basicUser: UserData = {
         ...maxUser,
         tier: 'basic',
@@ -752,10 +756,11 @@ describe('useTier', () => {
       mockUseGatewayzAuth.mockReturnValue({ userData: basicUser });
       rerender();
 
-      expect(result.current.tier).toBe('basic');
+      expect(result.current.tier).toBe('free');
       expect(result.current.hasSubscription).toBe(false);
       expect(result.current.canAccessModel('max')).toBe(false);
       expect(result.current.canAccessModel('pro')).toBe(false);
+      expect(result.current.canAccessModel('basic')).toBe(false);
     });
   });
 });

--- a/src/lib/__tests__/tier-utils.test.ts
+++ b/src/lib/__tests__/tier-utils.test.ts
@@ -1286,26 +1286,25 @@ describe('tier-utils', () => {
       expect(canAccessModel('max', getUserTier(maxUserWithStaleTrialStatus))).toBe(true);
     });
 
-    it('should correctly handle pro tier user with stale expired subscription_status (bug fix)', () => {
-      // Another bug scenario: user upgraded to pro but subscription_status is stale 'expired'
-      const proUserWithStaleExpiredStatus: UserData = {
+    it('should treat "expired" as terminal, not stale — cancelled/expired subscriber with leftover credits shows free', () => {
+      // 'expired' is a terminal status, not a "webhook hasn't caught up yet" status.
+      // A user whose subscription actually expired should see 'free' even with a
+      // stale paid `tier` column and leftover purchased credits.
+      const proUserWithExpiredStatus: UserData = {
         user_id: 555,
         api_key: 'test-key',
         auth_method: 'email',
         privy_user_id: 'privy-555',
-        display_name: 'Pro User with Stale Expired',
+        display_name: 'Pro User with Expired Subscription',
         email: 'pro@example.com',
         credits: 5000,
         tier: 'pro',
-        subscription_status: 'expired', // Stale - should have been updated to 'active'
+        subscription_status: 'expired',
       };
 
-      // The key assertion: user with pro tier should NOT appear as expired
-      expect(getUserTier(proUserWithStaleExpiredStatus)).toBe('pro');
-      expect(isOnTrial(proUserWithStaleExpiredStatus)).toBe(false);
-      expect(isTrialExpired(proUserWithStaleExpiredStatus)).toBe(false);
-      // Pro tier user should have access to pro features
-      expect(canAccessModel('pro', getUserTier(proUserWithStaleExpiredStatus))).toBe(true);
+      expect(getUserTier(proUserWithExpiredStatus)).toBe('free');
+      expect(isOnTrial(proUserWithExpiredStatus)).toBe(false);
+      expect(canAccessModel('pro', getUserTier(proUserWithExpiredStatus))).toBe(false);
     });
 
     it('should correctly handle basic user who purchased credits with stale trial status (bug fix)', () => {
@@ -1329,8 +1328,11 @@ describe('tier-utils', () => {
       expect(isTrialExpired(basicUserWithPurchasedCredits)).toBe(false);
     });
 
-    it('should correctly handle basic user who purchased credits with stale expired status (bug fix)', () => {
-      // Scenario: basic tier user purchased credits but subscription_status still shows 'expired'
+    it('should return free for a basic-tier user with leftover purchased credits and expired status', () => {
+      // Scenario: basic tier user has leftover purchased credits but subscription_status
+      // is 'expired' — a genuinely ended subscription, not a webhook-lag artifact.
+      // Cosmetic badge must show 'free', not 'basic' (backend independently blocks
+      // inference for this status regardless of this frontend value).
       const basicUserWithPurchasedCreditsExpired: UserData = {
         user_id: 777,
         api_key: 'test-key',
@@ -1340,14 +1342,69 @@ describe('tier-utils', () => {
         email: 'basic-expired@example.com',
         credits: 5000, // More than 500 cents ($5 trial) = purchased (this is $50)
         tier: 'basic',
-        subscription_status: 'expired', // Stale - user has paid for credits
+        subscription_status: 'expired',
       };
 
-      // The key assertion: user who has purchased credits should NOT appear as expired
-      expect(getUserTier(basicUserWithPurchasedCreditsExpired)).toBe('basic');
+      expect(getUserTier(basicUserWithPurchasedCreditsExpired)).toBe('free');
       expect(hasPurchasedCredits(basicUserWithPurchasedCreditsExpired)).toBe(true);
       expect(isOnTrial(basicUserWithPurchasedCreditsExpired)).toBe(false);
-      expect(isTrialExpired(basicUserWithPurchasedCreditsExpired)).toBe(false);
+    });
+
+    it('should return free for a cancelled subscriber with leftover purchased credits (cosmetic badge fix)', () => {
+      // The core bug this fix addresses: backend downgrades `tier` to 'basic' on
+      // cancellation without zeroing leftover purchased credits. Previously,
+      // hasPurchasedCredits() firing here caused the UI to show a "Basic" paid badge
+      // for a subscriber who cancelled weeks ago. Must now show 'free'.
+      const cancelledUserWithLeftoverCredits: UserData = {
+        user_id: 888,
+        api_key: 'test-key',
+        auth_method: 'email',
+        privy_user_id: 'privy-888',
+        display_name: 'Cancelled User with Leftover Credits',
+        email: 'cancelled-leftover@example.com',
+        credits: 5000, // $50 leftover purchased credits
+        tier: 'basic', // backend downgrades tier column to 'basic' on cancellation
+        subscription_status: 'cancelled',
+      };
+
+      expect(getUserTier(cancelledUserWithLeftoverCredits)).toBe('free');
+      expect(hasActiveSubscription(cancelledUserWithLeftoverCredits)).toBe(false);
+    });
+
+    it('should keep trusting purchased credits for the genuine webhook-lag case (stale inactive status)', () => {
+      // The original bug this override fixes: user just paid, but subscription_status
+      // hasn't been flipped from 'inactive'/null to 'active' yet due to webhook delay.
+      const freshlyPaidUserWithLaggingWebhook: UserData = {
+        user_id: 999,
+        api_key: 'test-key',
+        auth_method: 'email',
+        privy_user_id: 'privy-999-lag',
+        display_name: 'Freshly Paid User (webhook lag)',
+        email: 'webhook-lag@example.com',
+        credits: 3500, // $35 — just purchased basic tier credits
+        tier: 'basic',
+        subscription_status: 'inactive', // Stale — webhook hasn't updated to 'active' yet
+      };
+
+      expect(getUserTier(freshlyPaidUserWithLaggingWebhook)).toBe('basic');
+    });
+
+    it('should NOT upgrade a never-subscribed free user with leftover credits but non-paid tier', () => {
+      // Sanity check: the override only ever applies when isPaidTier is already true.
+      // A user with tier undefined/unset (or explicitly 'free') and >$5 credits but
+      // no paid tier field must stay 'free'.
+      const freeUserWithCredits: UserData = {
+        user_id: 1000,
+        api_key: 'test-key',
+        auth_method: 'email',
+        privy_user_id: 'privy-1000',
+        display_name: 'Free User with Credits',
+        email: 'free-credits@example.com',
+        credits: 5000, // $50 in credits, but never subscribed to a paid tier
+      };
+
+      expect(hasPurchasedCredits(freeUserWithCredits)).toBe(true);
+      expect(getUserTier(freeUserWithCredits)).toBe('free');
     });
   });
 });

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -548,7 +548,8 @@ export class AuthService {
         apiKey: data.api_key,
         email: data.email || userData?.email || '',
         displayName: data.display_name || userData?.display_name || '',
-        credits: Math.floor(data.credits ?? userData?.credits ?? 0),
+        // Keep credits as float (1 credit = $1) — consistent with processAuthResponse
+        credits: data.credits ?? userData?.credits ?? 0,
         tier: (data.tier?.toLowerCase() || userData?.tier || 'free') as UserTier,
         tierDisplayName: data.tier_display_name || userData?.tier_display_name,
         subscriptionStatus: data.subscription_status || userData?.subscription_status,

--- a/src/lib/tier-utils.ts
+++ b/src/lib/tier-utils.ts
@@ -87,13 +87,42 @@ const inferTierFromDisplayName = (tierDisplayName: string | undefined): UserTier
 };
 
 /**
+ * Subscription statuses under which a stale-but-paid `tier` field plus
+ * hasPurchasedCredits() is trusted as "the user just paid and the webhook
+ * hasn't caught up yet" — i.e. the user has never had a subscription that
+ * has since ended negatively.
+ *
+ * Deliberately an ALLOWLIST rather than a blocklist of terminal statuses
+ * ('cancelled', 'expired', 'past_due', ...): a subscriber whose plan actually
+ * ended must fall through to 'free' even if they still have leftover
+ * purchased credits (the backend downgrades `tier` to 'basic' on cancellation
+ * without zeroing credits, and independently blocks inference for those
+ * statuses regardless of this frontend value — this override is purely about
+ * not showing a misleading paid-tier badge). An allowlist also avoids having
+ * to enumerate every terminal-status spelling that might appear
+ * (e.g. "canceled" vs "cancelled").
+ */
+const STATUSES_ELIGIBLE_FOR_CREDIT_OVERRIDE = new Set<string>(['inactive', 'trial']);
+
+const isEligibleForPurchasedCreditsOverride = (
+  subscriptionStatus: SubscriptionStatus | undefined
+): boolean => {
+  // No status recorded at all — brand new user, never subscribed.
+  if (!subscriptionStatus) return true;
+  return STATUSES_ELIGIBLE_FOR_CREDIT_OVERRIDE.has(subscriptionStatus);
+};
+
+/**
  * Determines the user's current tier based on subscription status and tier field.
  *
  * Primary gate: subscription_status === 'active' → trust the tier field.
  * Secondary gate: hasPurchasedCredits → trust the tier field even with stale
- *   subscription_status (e.g. after a webhook delay or one-time credit purchase).
+ *   subscription_status (e.g. after a webhook delay or one-time credit purchase),
+ *   but ONLY when subscription_status indicates the user has never had a
+ *   subscription that ended negatively (see isEligibleForPurchasedCreditsOverride).
  * Everyone else: return 'free' — they have not paid, regardless of what the
- *   DB tier column says (it defaults to 'basic' for all new users).
+ *   DB tier column says (it defaults to 'basic' for all new users), and
+ *   regardless of leftover purchased credits for a cancelled/expired subscriber.
  *
  * @param userData - User data from auth response
  * @returns The current tier ('free', 'basic', 'pro', or 'max')
@@ -114,8 +143,14 @@ export const getUserTier = (userData: UserData | null): UserTier => {
   }
 
   // Stale subscription_status but user has clearly purchased credits (> $5 trial amount)
-  // This handles webhook delays and one-time credit purchases with stale status
-  if (isPaidTier && hasPurchasedCredits(userData)) {
+  // This handles webhook delays and one-time credit purchases with stale status —
+  // but never for a subscriber whose subscription has actually ended (cancelled,
+  // expired, past_due, ...); those users must see 'free' regardless of leftover credits.
+  if (
+    isPaidTier &&
+    isEligibleForPurchasedCreditsOverride(userData.subscription_status) &&
+    hasPurchasedCredits(userData)
+  ) {
     return tier as UserTier;
   }
 


### PR DESCRIPTION
## Summary
Two audit-confirmed findings, both re-scoped after investigation revealed they were more nuanced than first flagged. Both fixes approved by user before implementation (billing-adjacent behavior, not clear-cut one-liners).

- **Tier badge (cosmetic, not a security issue)**: `getUserTier()`'s `hasPurchasedCredits()` override — added to fix a *different* bug (webhook-lag showing a stale downgrade banner right after a fresh purchase) — was too broad: it also kept showing a paid ("Basic") badge to subscribers who had properly *cancelled* weeks ago but still had >$5 of leftover purchased credits (which the backend deliberately doesn't zero out on cancellation). Confirmed via backend audit that this was **cosmetic only** — the backend independently blocks all inference for cancelled/expired subscriptions via a separate `subscription_status` gate, regardless of this frontend tier value, so there was never any real access-control or revenue exposure. Narrowed the override to an explicit allowlist (`undefined`/`inactive`/`trial`) so it only fires for the webhook-lag case it was built for; cancelled/expired subscribers now correctly show `free`.
- **Credits flooring**: investigated as a possible regression, turned out to be the *opposite* — fractional credits (`$150.75`) are the correct, deliberate, backend-verified design (confirmed via a purpose-built `formatCredits()` utility, `numeric(10,2)` DB columns, explicit backend "no unit conversion" comments). The one failing test was simply stale. While investigating, found a real, separate, small bug: `auth-service.ts`'s `refresh()` method still did `Math.floor(credits)`, inconsistent with its own `processAuthResponse` in the same file — a user's displayed balance could silently truncate after a session refresh. Fixed both.

## Test plan
- [x] Full `jest` suite diffed against `master`: zero new failures, one suite fixed (`SessionInitializer.test.tsx`) as expected — net 268 failing vs 272 on master (4 more tests passing, all attributable to these fixes).
- [x] `tsc --noEmit`: byte-identical output to `master`.
- [x] New/updated unit tests for `tier-utils.ts` covering: active subscriber (unchanged), webhook-lag case (unchanged, the original bug this override fixes), cancelled+credits>$5 (now correctly `free`), never-subscribed free user (sanity check, unchanged).

## Also found, not fixed (flagging for a future pass)
Discovered ~37 pre-existing, unrelated test failures in `tier-utils.test.ts`/`use-tier.test.ts` caused by stale test fixtures written under an old cents-based mental model (`credits: 100` intended as "$1.00") that doesn't match the app's actual, consistently-dollars-based convention (`1 credit = $1`, confirmed by both this and the prior credits audit). Not a production bug — just old test fixtures — left untouched, out of scope for this PR.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved fractional credit values instead of rounding them down.
  * Improved account tier detection so cancelled, expired, or otherwise inactive subscriptions now correctly show as **Free** and block paid-tier access.
  * Kept recently paid accounts on their current tier during brief status delays, while still handling leftover purchased credits correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->