### PR TITLE
feat: friendly error copy, telemetry-only raw errors, scope-aware 429 handling

### DIFF
--- a/src/__tests__/lib/backend-error-tracking.test.ts
+++ b/src/__tests__/lib/backend-error-tracking.test.ts
@@ -116,7 +116,7 @@ describe('backend-error-tracking', () => {
 
     it('should include response body preview in context', () => {
       const error = new Error('Test error');
-      const longBody = 'x'.repeat(600);
+      const longBody = 'x'.repeat(2600);
 
       trackBackendError(error, {
         endpoint: '/api/test',
@@ -128,7 +128,39 @@ describe('backend-error-tracking', () => {
         expect.objectContaining({
           contexts: expect.objectContaining({
             backend_api: expect.objectContaining({
-              response_preview: longBody.slice(0, 500),
+              response_body: longBody.slice(0, 2000),
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should include model, request ID, error code/type, and rate-limit scope', () => {
+      const error = new Error('Test error');
+
+      trackBackendError(error, {
+        endpoint: '/v1/chat/completions',
+        statusCode: 429,
+        model: 'deepseek/deepseek-r1',
+        requestId: 'req_abc123',
+        errorCode: 'RATE_LIMIT_EXCEEDED',
+        errorType: 'rate_limit_error',
+        rateLimitScope: 'upstream',
+      });
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          tags: expect.objectContaining({
+            model: 'deepseek/deepseek-r1',
+            backend_error_code: 'RATE_LIMIT_EXCEEDED',
+            backend_error_type: 'rate_limit_error',
+            rate_limit_scope: 'upstream',
+          }),
+          contexts: expect.objectContaining({
+            backend_api: expect.objectContaining({
+              request_id: 'req_abc123',
+              rate_limit_scope: 'upstream',
             }),
           }),
         })

--- a/src/app/api/chat/ai-sdk-completions/route.ts
+++ b/src/app/api/chat/ai-sdk-completions/route.ts
@@ -108,14 +108,25 @@ export async function POST(request: NextRequest) {
         const errorText = await response.text();
         let errorData: any;
         try { errorData = JSON.parse(errorText); } catch { errorData = { raw: errorText }; }
+
+        // Forward the full backend error body plus the headers the client
+        // needs to classify the failure (rate-limit scope, retry timing,
+        // request ID). The client maps these to friendly copy — raw text is
+        // never rendered.
+        const errorHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        for (const name of ['retry-after', 'x-ratelimit-scope', 'x-ratelimit-limit', 'x-ratelimit-remaining', 'x-ratelimit-reset', 'x-request-id']) {
+          const value = response.headers.get(name);
+          if (value) errorHeaders[name] = value;
+        }
+
         return new Response(JSON.stringify({
           error: 'Backend API Error',
           status: response.status,
-          message: errorData.message || errorData.detail || errorText.substring(0, 500),
           model: body.model,
+          errorData,
         }), {
           status: response.status,
-          headers: { 'Content-Type': 'application/json' },
+          headers: errorHeaders,
         });
       }
 

--- a/src/app/api/chat/completions/route.ts
+++ b/src/app/api/chat/completions/route.ts
@@ -63,6 +63,29 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Headers the client needs to classify errors correctly: rate-limit scope
+ * (upstream vs gateway 429), retry timing, and the request ID for support
+ * tracing. Forwarded verbatim from the backend response.
+ */
+const FORWARDED_ERROR_HEADERS = [
+  'retry-after',
+  'x-ratelimit-scope',
+  'x-ratelimit-limit',
+  'x-ratelimit-remaining',
+  'x-ratelimit-reset',
+  'x-request-id',
+] as const;
+
+function forwardErrorHeaders(backendResponse: Response): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  for (const name of FORWARDED_ERROR_HEADERS) {
+    const value = backendResponse.headers.get(name);
+    if (value) headers[name] = value;
+  }
+  return headers;
+}
+
+/**
  * Process LLM completion without tracing
  */
 async function processCompletion(
@@ -123,22 +146,33 @@ async function processCompletion(
             }
 
             const retryAfter = response.headers.get('retry-after');
+            const rateLimitScope = response.headers.get('x-ratelimit-scope');
+            const isUpstreamLimit = rateLimitScope?.toLowerCase() === 'upstream';
             const isBurstLimit = errorData.detail?.toLowerCase().includes('burst') || false;
 
             console.warn(`[API Proxy] Rate limit error (429) on attempt ${retryCount + 1}/${maxRetries + 1}`);
             console.warn('[API Proxy] Error detail:', errorData.detail || errorData.message);
             console.warn('[API Proxy] Retry-After header:', retryAfter || 'not present');
+            console.warn('[API Proxy] X-RateLimit-Scope:', rateLimitScope || 'not present');
             console.warn('[API Proxy] Is burst limit:', isBurstLimit);
 
-            if (retryCount < maxRetries) {
+            // Upstream (model provider) limits surface to the client immediately;
+            // only gateway limits get silent server-side retries.
+            if (!isUpstreamLimit && retryCount < maxRetries) {
               lastError = { status: 429, errorData, retryAfter };
               // Use isBurstLimit for logging context
               console.log(`[API Proxy] Will retry (burst limit: ${isBurstLimit})`);
               continue; // Retry
-            } else {
-              // Max retries exceeded
-              throw new Error(`Rate limit exceeded after ${maxRetries + 1} attempts: ${errorData.detail || errorData.message || 'Rate limit exceeded'}`);
             }
+
+            const error: any = new Error(`Backend API Error: 429 Too Many Requests`);
+            error.status = 429;
+            error.statusText = 'Too Many Requests';
+            error.errorData = errorData;
+            error.retryAfter = retryAfter;
+            error.rateLimitScope = rateLimitScope;
+            error.requestId = response.headers.get('x-request-id');
+            throw error;
           }
 
           // Handle error responses (4xx, 5xx) for non-streaming requests
@@ -159,6 +193,9 @@ async function processCompletion(
             error.status = response.status;
             error.statusText = response.statusText;
             error.errorData = errorData;
+            error.retryAfter = response.headers.get('retry-after');
+            error.rateLimitScope = response.headers.get('x-ratelimit-scope');
+            error.requestId = response.headers.get('x-request-id');
             throw error;
           }
 
@@ -471,37 +508,40 @@ export async function POST(request: NextRequest) {
             }
 
             const retryAfter = response.headers.get('retry-after');
+            const rateLimitScope = response.headers.get('x-ratelimit-scope');
+            const isUpstreamLimit = rateLimitScope?.toLowerCase() === 'upstream';
             const isBurstLimit = errorData.detail?.toLowerCase().includes('burst') || false;
 
             console.warn(`[API Proxy] Rate limit error (429) on attempt ${retryCount + 1}/${maxRetries + 1}`);
             console.warn('[API Proxy] Error detail:', errorData.detail || errorData.message);
             console.warn('[API Proxy] Retry-After header:', retryAfter || 'not present');
+            console.warn('[API Proxy] X-RateLimit-Scope:', rateLimitScope || 'not present');
             console.warn('[API Proxy] Is burst limit:', isBurstLimit);
 
-            if (retryCount < maxRetries) {
+            // Upstream (model provider) limits go straight to the client, which
+            // owns the countdown + single auto-retry UX. Only gateway limits
+            // get the silent server-side retry.
+            if (!isUpstreamLimit && retryCount < maxRetries) {
               lastError = { status: 429, errorData, retryAfter };
               continue; // Retry - delay already calculated in next iteration
-            } else {
-              // Max retries exceeded
-              console.error('[API Proxy] Max retries exceeded for rate limit');
-              return new Response(JSON.stringify({
-                error: 'Rate Limit Exceeded',
-                status: 429,
-                statusText: 'Too Many Requests',
-                message: errorData.detail || errorData.message || 'Rate limit exceeded. Please wait before trying again.',
-                model: body.model,
-                gateway: body.gateway,
-                errorData: errorData,
-                retryAfter: retryAfter,
-                retriesExhausted: true,
-              }), {
-                status: 429,
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Retry-After': retryAfter || '60',
-                },
-              });
             }
+
+            console.error(`[API Proxy] Returning 429 to client (scope: ${rateLimitScope || 'gateway'})`);
+            const rateLimitHeaders = forwardErrorHeaders(response);
+            if (!rateLimitHeaders['retry-after']) rateLimitHeaders['retry-after'] = '60';
+            return new Response(JSON.stringify({
+              error: 'Rate Limit Exceeded',
+              status: 429,
+              statusText: 'Too Many Requests',
+              model: body.model,
+              gateway: body.gateway,
+              errorData: errorData,
+              retryAfter: retryAfter,
+              retriesExhausted: !isUpstreamLimit,
+            }), {
+              status: 429,
+              headers: rateLimitHeaders,
+            });
           }
 
           if (!response.ok) {
@@ -643,7 +683,7 @@ export async function POST(request: NextRequest) {
               errorData: errorData
             }), {
               status: response.status,
-              headers: { 'Content-Type': 'application/json' },
+              headers: forwardErrorHeaders(response),
             });
           }
 
@@ -927,6 +967,12 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      // Forward rate-limit / tracing headers captured when the backend error was thrown
+      const httpErrorHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (httpError.retryAfter) httpErrorHeaders['retry-after'] = String(httpError.retryAfter);
+      if (httpError.rateLimitScope) httpErrorHeaders['x-ratelimit-scope'] = String(httpError.rateLimitScope);
+      if (httpError.requestId) httpErrorHeaders['x-request-id'] = String(httpError.requestId);
+
       return new Response(JSON.stringify({
         error: 'Backend API Error',
         status: httpError.status,
@@ -936,7 +982,7 @@ export async function POST(request: NextRequest) {
         errorData: errorData
       }), {
         status: httpError.status,
-        headers: { 'Content-Type': 'application/json' },
+        headers: httpErrorHeaders,
       });
     }
 

--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -20,6 +20,7 @@ import { Slider } from '@/components/ui/slider';
 import { Label } from '@/components/ui/label';
 import { ReasoningDisplay } from '@/components/chat/reasoning-display';
 import { streamChatResponse } from '@/lib/streaming/stream-chat';
+import { fromUnknown, getUserMessage } from '@/lib/errors';
 import { usePrivy } from '@privy-io/react-auth';
 import { getApiKey } from '@/lib/api';
 import {
@@ -152,14 +153,12 @@ export default function PlaygroundPage() {
 
       setMessages((prev) => [...prev, assistantMessage]);
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'An error occurred';
-
       console.error('Error sending message:', error);
 
+      // Friendly copy only — raw error text stays in telemetry/console.
       toast({
         title: 'Error',
-        description: errorMessage,
+        description: getUserMessage(fromUnknown(error)),
         variant: 'destructive',
       });
     } finally {

--- a/src/app/settings/cache/page.tsx
+++ b/src/app/settings/cache/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useGatewayzAuth } from "@/context/gatewayz-auth-context";
 import { makeAuthenticatedRequest } from "@/lib/api";
 import { API_BASE_URL } from "@/lib/config";
+import { fromUnknown, getUserMessage, parseErrorResponse } from "@/lib/errors";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
 
@@ -68,15 +69,13 @@ export default function CachePage() {
             : "Prompt caching has been turned off.",
         });
       } else {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.detail || errorData.message || "Failed to update cache settings");
+        throw await parseErrorResponse(response, "Failed to update cache settings");
       }
     } catch (error) {
       console.error("Error updating cache settings:", error);
-      const errorMessage = error instanceof Error ? error.message : "Please try again later";
       toast({
         title: "Failed to update setting",
-        description: errorMessage,
+        description: getUserMessage(fromUnknown(error)),
         variant: "destructive",
       });
     } finally {

--- a/src/app/v1/chat/completions/route.ts
+++ b/src/app/v1/chat/completions/route.ts
@@ -227,17 +227,25 @@ export async function POST(request: NextRequest) {
           console.error('[API Proxy] Model ID sent to backend:', body.model);
           console.error('[API Proxy] Gateway param sent to backend:', body.gateway);
 
+          // Forward the headers the client needs to classify the failure
+          // (rate-limit scope, retry timing, request ID). The client maps the
+          // errorData body to friendly copy — raw text is never rendered.
+          const errorHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+          for (const name of ['retry-after', 'x-ratelimit-scope', 'x-ratelimit-limit', 'x-ratelimit-remaining', 'x-ratelimit-reset', 'x-request-id']) {
+            const value = response.headers.get(name);
+            if (value) errorHeaders[name] = value;
+          }
+
           return new Response(JSON.stringify({
             error: 'Backend API Error',
             status: response.status,
             statusText: response.statusText,
-            message: errorData.message || errorData.detail || errorText.substring(0, 500),
             model: body.model,
             gateway: body.gateway,
             errorData: errorData
           }), {
             status: response.status,
-            headers: { 'Content-Type': 'application/json' },
+            headers: errorHeaders,
           });
         }
 

--- a/src/components/chat-v2/MessageList.tsx
+++ b/src/components/chat-v2/MessageList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { ChatMessage as ChatMessageBubble } from "@/components/chat/ChatMessage";
+import type { ChatErrorInfo, RetryNotice } from "@/components/chat/ChatMessage";
 import type { ChatMessage as ChatMessageData } from "@/lib/chat-history";
 
 const getTextFromContent = (content: string | any[]): string => {
@@ -17,7 +18,13 @@ const getTextFromContent = (content: string | any[]): string => {
 
 interface MessageListProps {
   sessionId: number | null;
-  messages: (ChatMessageData & { error?: string; hasError?: boolean; wasStopped?: boolean })[];
+  messages: (ChatMessageData & {
+    error?: string;
+    hasError?: boolean;
+    wasStopped?: boolean;
+    errorInfo?: ChatErrorInfo;
+    retryNotice?: RetryNotice;
+  })[];
   isLoading: boolean;
   pendingPrompt?: string | null;  // Optimistic message shown while session is being created
   onRetry?: () => void;  // Callback to retry the last failed message
@@ -189,6 +196,8 @@ export function MessageList({ sessionId, messages, isLoading, pendingPrompt, onR
             model={msg.model}
             error={msg.error}
             hasError={msg.hasError}
+            errorInfo={msg.errorInfo}
+            retryNotice={msg.retryNotice}
             // Search/tool call state
             isSearching={msg.isSearching}
             searchQuery={msg.searchQuery}

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -5,10 +5,10 @@
  * Performance improvement: 50% less re-rendering
  */
 
-import React, { memo, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Card } from '@/components/ui/card';
-import { Bot, User, Copy, RotateCcw, LogIn, Check, FileText, RefreshCw, ThumbsUp, ThumbsDown, Share, MoreHorizontal } from 'lucide-react';
+import { Bot, User, Copy, RotateCcw, LogIn, Check, FileText, RefreshCw, ThumbsUp, ThumbsDown, Share, MoreHorizontal, CreditCard, Clock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import dynamic from 'next/dynamic';
 import { usePrivy } from '@privy-io/react-auth';
@@ -24,6 +24,22 @@ const ReasoningDisplay = dynamic(
 );
 const SearchResults = dynamic(() => import('@/components/chat/SearchResults'), { ssr: true });
 
+/** Structured error metadata attached by use-chat-stream (from the classified AppError). */
+export interface ChatErrorInfo {
+  code?: string;
+  retryable?: boolean;
+  requestId?: string;
+  retryAfterSeconds?: number;
+  rateLimitScope?: 'upstream' | 'gateway';
+}
+
+/** Live rate-limit retry state while the stream layer waits out Retry-After. */
+export interface RetryNotice {
+  scope: 'upstream' | 'gateway';
+  retryAfterMs: number;
+  startedAt: number;
+}
+
 export interface ChatMessageProps {
   role: 'user' | 'assistant';
   content: string | any[];
@@ -38,6 +54,8 @@ export interface ChatMessageProps {
   model?: string;
   error?: string;
   hasError?: boolean;
+  errorInfo?: ChatErrorInfo;
+  retryNotice?: RetryNotice;
   onCopy?: () => void;
   onRegenerate?: () => void;
   onRetry?: () => void;
@@ -69,7 +87,8 @@ const contentEquals = (a: string | any[], b: string | any[]): boolean => {
   return false;
 };
 
-// Check if error is related to authentication/sign-in
+// Fallback classification from the (already-safe) display copy, used only when
+// no structured errorInfo is available (e.g. legacy messages).
 const isAuthError = (error: string): boolean => {
   const lowerError = error.toLowerCase();
   return (
@@ -81,7 +100,6 @@ const isAuthError = (error: string): boolean => {
   );
 };
 
-// Check if error is related to rate limiting
 const isRateLimitError = (error: string): boolean => {
   const lowerError = error.toLowerCase();
   return (
@@ -89,41 +107,133 @@ const isRateLimitError = (error: string): boolean => {
     lowerError.includes('too many requests') ||
     lowerError.includes('temporarily unavailable') ||
     lowerError.includes('high demand') ||
-    lowerError.includes('429')
+    lowerError.includes('busy right now') ||
+    lowerError.includes('too quickly')
   );
 };
 
-// Error display component with sign-in button for auth errors and retry for rate limits
-const ErrorDisplay = ({ error, onRetry }: { error: string; onRetry?: () => void }) => {
+const AUTH_ERROR_CODES = new Set(['AUTH_REQUIRED', 'AUTH_EXPIRED', 'AUTH_INVALID']);
+const RETRYABLE_ERROR_CODES = new Set([
+  'API_RATE_LIMITED',
+  'API_UPSTREAM_RATE_LIMITED',
+  'API_SERVER_ERROR',
+  'NETWORK_ERROR',
+  'NETWORK_TIMEOUT',
+  'CHAT_STREAM_ERROR',
+  'CHAT_MODEL_ERROR',
+]);
+
+// Error display: friendly copy plus an action matched to the error kind —
+// sign in (auth), add credits (402), renew (inactive subscription), or retry.
+// Shows the backend request ID subtly so support can trace the failure.
+const ErrorDisplay = ({
+  error,
+  errorInfo,
+  onRetry,
+}: {
+  error: string;
+  errorInfo?: ChatErrorInfo;
+  onRetry?: () => void;
+}) => {
   const { login } = usePrivy();
-  const showSignIn = isAuthError(error);
-  const showRetry = isRateLimitError(error) && onRetry;
+  const code = errorInfo?.code;
+
+  const showSignIn = code ? AUTH_ERROR_CODES.has(code) : isAuthError(error);
+  const showAddCredits = code === 'API_PAYMENT_REQUIRED';
+  const showRenew = code === 'SUBSCRIPTION_INACTIVE';
+  const showRetry =
+    !!onRetry &&
+    !showSignIn &&
+    !showAddCredits &&
+    !showRenew &&
+    (errorInfo?.retryable || (code ? RETRYABLE_ERROR_CODES.has(code) : isRateLimitError(error)));
 
   return (
     <div className="mt-2 p-3 bg-destructive/10 border border-destructive/20 rounded text-sm text-destructive">
       <p className="mb-0">{error}</p>
-      {showSignIn && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-2 border-destructive/30 hover:bg-destructive/10"
-          onClick={() => login()}
-        >
-          <LogIn className="h-4 w-4 mr-2" />
-          Sign in to continue
-        </Button>
+      <div className="flex flex-wrap items-center gap-2">
+        {showSignIn && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 border-destructive/30 hover:bg-destructive/10"
+            onClick={() => login()}
+          >
+            <LogIn className="h-4 w-4 mr-2" />
+            Sign in to continue
+          </Button>
+        )}
+        {showAddCredits && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 border-destructive/30 hover:bg-destructive/10"
+            asChild
+          >
+            <a href="/settings/credits">
+              <CreditCard className="h-4 w-4 mr-2" />
+              Add credits
+            </a>
+          </Button>
+        )}
+        {showRenew && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 border-destructive/30 hover:bg-destructive/10"
+            asChild
+          >
+            <a href="/settings?tab=billing">
+              <CreditCard className="h-4 w-4 mr-2" />
+              Renew subscription
+            </a>
+          </Button>
+        )}
+        {showRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 border-destructive/30 hover:bg-destructive/10"
+            onClick={onRetry}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Try again
+          </Button>
+        )}
+      </div>
+      {errorInfo?.requestId && (
+        <p className="mt-2 mb-0 text-xs text-muted-foreground">Error ID: {errorInfo.requestId}</p>
       )}
-      {showRetry && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-2 border-destructive/30 hover:bg-destructive/10"
-          onClick={onRetry}
-        >
-          <RefreshCw className="h-4 w-4 mr-2" />
-          Try again
-        </Button>
-      )}
+    </div>
+  );
+};
+
+// Live countdown shown while the stream layer waits out a rate limit before
+// automatically retrying (upstream 429s retry once after Retry-After).
+const RetryCountdownNotice = ({ notice }: { notice: RetryNotice }) => {
+  const remainingMs = () => Math.max(0, notice.retryAfterMs - (Date.now() - notice.startedAt));
+  const [secondsLeft, setSecondsLeft] = useState(() => Math.ceil(remainingMs() / 1000));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setSecondsLeft(Math.ceil(remainingMs() / 1000));
+    }, 250);
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notice.retryAfterMs, notice.startedAt]);
+
+  const copy =
+    notice.scope === 'upstream'
+      ? 'This model is busy right now — retrying'
+      : "You're sending requests too quickly — retrying";
+
+  return (
+    <div className="mt-2 flex items-center gap-2 p-3 bg-amber-500/10 border border-amber-500/20 rounded text-sm text-amber-700 dark:text-amber-400">
+      <Clock className="h-4 w-4 shrink-0" />
+      <span>
+        {copy}
+        {secondsLeft > 0 ? ` in ${secondsLeft}s…` : '…'}
+      </span>
     </div>
   );
 };
@@ -180,6 +290,8 @@ export const ChatMessage = memo<ChatMessageProps>(
     model,
     error,
     hasError,
+    errorInfo,
+    retryNotice,
     onCopy,
     onRegenerate,
     onRetry,
@@ -348,7 +460,12 @@ export const ChatMessage = memo<ChatMessageProps>(
 
             {/* Error display */}
             {hasError && error && (
-              <ErrorDisplay error={error} onRetry={onRetry} />
+              <ErrorDisplay error={error} errorInfo={errorInfo} onRetry={onRetry} />
+            )}
+
+            {/* Rate-limit auto-retry countdown (stream layer is waiting to retry) */}
+            {isStreaming && retryNotice && (
+              <RetryCountdownNotice notice={retryNotice} />
             )}
 
             {/* Streaming indicator with timer */}
@@ -486,6 +603,8 @@ export const ChatMessage = memo<ChatMessageProps>(
       prevProps.document === nextProps.document &&
       prevProps.error === nextProps.error &&
       prevProps.hasError === nextProps.hasError &&
+      JSON.stringify(prevProps.errorInfo) === JSON.stringify(nextProps.errorInfo) &&
+      JSON.stringify(prevProps.retryNotice) === JSON.stringify(nextProps.retryNotice) &&
       prevProps.showActions === nextProps.showActions &&
       prevProps.onCopy === nextProps.onCopy &&
       prevProps.onRetry === nextProps.onRetry &&

--- a/src/components/models/inline-chat.tsx
+++ b/src/components/models/inline-chat.tsx
@@ -8,6 +8,7 @@ import { Send, Loader2 } from 'lucide-react';
 import { getApiKey, getUserData } from '@/lib/api';
 // Using modular streaming - the old streaming.ts is deprecated
 import { streamChatResponse } from '@/lib/streaming/index';
+import { fromUnknown, getUserMessage } from '@/lib/errors';
 import { normalizeModelId } from '@/lib/utils';
 import ReactMarkdown from 'react-markdown';
 import remarkMath from 'remark-math';
@@ -249,22 +250,9 @@ export function InlineChat({ modelId, modelName, gateway }: InlineChatProps) {
 
     } catch (err) {
       console.error('[InlineChat] Error sending message:', err);
-      let errorMessage = 'Failed to send message';
-
-      if (err instanceof Error) {
-        errorMessage = err.message;
-      }
-
-      // Add helpful context if no response was received
-      if (accumulatedContent.length === 0) {
-        // If the error message doesn't already explain the issue, add context
-        if (!errorMessage.includes('not properly configured') && !errorMessage.includes('not support')) {
-          errorMessage = errorMessage || 'No response from model. ';
-          errorMessage += ' This could mean: the model is unavailable, your API key is invalid, or the model provider is having issues. Try again or select a different model.';
-        }
-      }
-
-      setError(errorMessage);
+      // Safe, user-facing copy only — raw error text goes to telemetry in the
+      // streaming layer, never to the screen.
+      setError(getUserMessage(fromUnknown(err)));
       // Remove the streaming message on error
       setMessages(prev => prev.slice(0, -1));
     } finally {

--- a/src/lib/backend-error-tracking.ts
+++ b/src/lib/backend-error-tracking.ts
@@ -23,6 +23,16 @@ export function trackBackendError(
     gateway?: string;
     retryCount?: number;
     responseBody?: string;
+    /** Model the failed request targeted (chat/image generation). */
+    model?: string;
+    /** Backend request ID (X-Request-ID / body request_id) for correlation. */
+    requestId?: string;
+    /** Backend error code from the response body (e.g. INSUFFICIENT_CREDITS, subscription_canceled). */
+    errorCode?: string;
+    /** Backend error type from the response body or SSE chunk (e.g. rate_limit_error). */
+    errorType?: string;
+    /** X-RateLimit-Scope header value on 429s (upstream vs gateway). */
+    rateLimitScope?: string;
   }
 ): void {
   const errorObj = typeof error === 'string' ? new Error(error) : error;
@@ -41,6 +51,10 @@ export function trackBackendError(
       http_status: context.statusCode?.toString() || 'unknown',
       http_method: context.method || 'GET',
       gateway: context.gateway || 'none',
+      ...(context.model ? { model: context.model } : {}),
+      ...(context.errorCode ? { backend_error_code: context.errorCode } : {}),
+      ...(context.errorType ? { backend_error_type: context.errorType } : {}),
+      ...(context.rateLimitScope ? { rate_limit_scope: context.rateLimitScope } : {}),
     },
     contexts: {
       backend_api: {
@@ -49,7 +63,12 @@ export function trackBackendError(
         method: context.method,
         gateway: context.gateway,
         retry_count: context.retryCount,
-        response_preview: context.responseBody?.slice(0, 500), // First 500 chars
+        model: context.model,
+        request_id: context.requestId,
+        error_code: context.errorCode,
+        error_type: context.errorType,
+        rate_limit_scope: context.rateLimitScope,
+        response_body: context.responseBody?.slice(0, 2000),
       }
     },
     fingerprint: [

--- a/src/lib/errors/__tests__/errors.test.ts
+++ b/src/lib/errors/__tests__/errors.test.ts
@@ -5,6 +5,7 @@
  */
 import {
   classifyApiError,
+  classifySseError,
   parseErrorResponse,
   fromStreamingError,
   fromUnknown,
@@ -95,6 +96,216 @@ describe('classifyApiError', () => {
     const msg = getUserMessage(err);
     expect(msg).not.toMatch(/NullPointerException|payment_processor|req_abc123/);
   });
+
+  it('captures the request ID as metadata (for "Error ID" display) without putting it in the copy', () => {
+    const err = classifyApiError(500, {
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'Internal server error (request ID: req_abc123)',
+        request_id: 'req_abc123',
+      },
+    });
+    expect(err.requestId).toBe('req_abc123');
+    expect(getUserMessage(err)).not.toMatch(/req_abc123/);
+  });
+
+  it('reads the request ID from the X-Request-ID header option when the body has none', () => {
+    const err = classifyApiError(500, {}, { requestId: 'req_header42' });
+    expect(err.requestId).toBe('req_header42');
+  });
+
+  describe('status/code → user copy mapping table', () => {
+    const cases: Array<{ name: string; status: number; body: unknown; opts?: Parameters<typeof classifyApiError>[2]; expected: RegExp; forbidden?: RegExp }> = [
+      {
+        name: '402 → not enough credits',
+        status: 402,
+        body: { detail: 'Insufficient credits. Required: $5.00' },
+        expected: /enough credits/i,
+        forbidden: /\$5\.00/,
+      },
+      {
+        name: '403 subscription_canceled → subscription inactive',
+        status: 403,
+        body: { error: { code: 'subscription_canceled', message: 'canceled sub_999' } },
+        expected: /subscription is inactive/i,
+        forbidden: /sub_999/,
+      },
+      {
+        name: '403 subscription_expired (via error.type) → subscription inactive',
+        status: 403,
+        body: { error: { type: 'subscription_expired', message: 'expired' } },
+        expected: /subscription is inactive/i,
+      },
+      {
+        name: '403 without subscription code → access copy, not subscription copy',
+        status: 403,
+        body: { error: { message: 'forbidden' } },
+        expected: /credential|access|denied|invalid/i,
+        forbidden: /subscription is inactive/i,
+      },
+      {
+        name: 'gateway 429 with Retry-After → wait N seconds',
+        status: 429,
+        body: { detail: 'Rate limit exceeded' },
+        opts: { retryAfter: 25 },
+        expected: /wait 25 seconds/i,
+        forbidden: /busy right now/i,
+      },
+      {
+        name: 'gateway 429 without Retry-After → generic too-quickly copy',
+        status: 429,
+        body: {},
+        expected: /too quickly/i,
+      },
+      {
+        name: 'upstream 429 → model busy, NOT phrased as the user hitting their own limit',
+        status: 429,
+        body: { detail: 'Provider openai rate limited' },
+        opts: { retryAfter: 10, rateLimitScope: 'upstream' },
+        expected: /busy right now/i,
+        forbidden: /too quickly|your.*limit|openai/i,
+      },
+      {
+        name: '404 → not found copy',
+        status: 404,
+        body: {},
+        expected: /not found/i,
+      },
+      {
+        name: '422 → validation copy',
+        status: 422,
+        body: { detail: [{ type: 'missing', loc: ['body'], msg: 'Field required' }] },
+        expected: /invalid|check/i,
+        forbidden: /Field required/,
+      },
+      {
+        name: '500 with no body → server copy',
+        status: 500,
+        body: undefined,
+        expected: /server|wrong/i,
+      },
+      {
+        name: '503 → server copy',
+        status: 503,
+        body: {},
+        expected: /server|unavailable|wrong/i,
+      },
+      {
+        name: 'unmapped status/code → generic something went wrong',
+        status: 418,
+        body: { error: { code: 'IM_A_TEAPOT', message: 'teapot detail' } },
+        expected: /something went wrong/i,
+        forbidden: /teapot/i,
+      },
+    ];
+
+    it.each(cases)('$name', ({ status, body, opts, expected, forbidden }) => {
+      const err = classifyApiError(status, body, opts);
+      const msg = getUserMessage(err);
+      expect(msg).toMatch(expected);
+      if (forbidden) {
+        expect(msg).not.toMatch(forbidden);
+      }
+    });
+  });
+
+  describe('upstream vs gateway 429 branching', () => {
+    it('marks upstream 429s with scope + retry-after metadata and keeps them retryable', () => {
+      const err = classifyApiError(429, {}, { rateLimitScope: 'upstream', retryAfter: 12 });
+      expect(err.rateLimitScope).toBe('upstream');
+      expect(err.retryAfterSeconds).toBe(12);
+      expect(err.code).toBe('API_UPSTREAM_RATE_LIMITED');
+      expect(err.retryable).toBe(true);
+    });
+
+    it('treats a 429 without the upstream scope header as a gateway limit', () => {
+      const err = classifyApiError(429, {}, { retryAfter: 8 });
+      expect(err.rateLimitScope).toBe('gateway');
+      expect(err.code).toBe('API_RATE_LIMITED');
+      expect(getUserMessage(err)).toMatch(/wait 8 seconds/i);
+    });
+
+    it('scope header comparison is case-insensitive', () => {
+      const err = classifyApiError(429, {}, { rateLimitScope: 'Upstream' });
+      expect(err.rateLimitScope).toBe('upstream');
+    });
+
+    it('keeps quota-specific copy for gateway DAILY_QUOTA_EXCEEDED', () => {
+      const err = classifyApiError(429, { error: { code: 'DAILY_QUOTA_EXCEEDED', message: 'quota' } });
+      expect(getUserMessage(err)).toMatch(/daily usage limit/i);
+    });
+
+    it('formats long Retry-After values as minutes/hours, not raw seconds', () => {
+      const minutes = classifyApiError(429, {}, { retryAfter: 300 });
+      expect(getUserMessage(minutes)).toMatch(/5 minutes/i);
+      const hours = classifyApiError(429, {}, { retryAfter: 7200 });
+      expect(getUserMessage(hours)).toMatch(/2 hours/i);
+    });
+
+    it('keeps sign-up copy for the guest daily limit (top-level code)', () => {
+      const err = classifyApiError(429, {
+        error: 'Daily limit reached',
+        code: 'GUEST_RATE_LIMIT_EXCEEDED',
+        message: "You've used all 10 free messages for today.",
+      });
+      expect(getUserMessage(err)).toMatch(/free messages for today.*sign up/is);
+    });
+  });
+
+  describe('proxy envelope unwrapping', () => {
+    it('classifies from the nested backend body wrapped by the Next.js proxy', () => {
+      const err = classifyApiError(402, {
+        error: 'Backend API Error',
+        status: 402,
+        message: 'raw passthrough detail',
+        errorData: {
+          error: { code: 'INSUFFICIENT_CREDITS', message: 'Insufficient credits. Required: $1.00' },
+        },
+      });
+      expect(getUserMessage(err)).toMatch(/credits/i);
+      expect(getUserMessage(err)).not.toMatch(/\$1\.00|raw passthrough/);
+    });
+
+    it('finds subscription codes inside the proxy envelope', () => {
+      const err = classifyApiError(403, {
+        error: 'Backend API Error',
+        errorData: { error: { code: 'subscription_past_due', message: 'past due' } },
+      });
+      expect(getUserMessage(err)).toMatch(/subscription is inactive/i);
+    });
+  });
+});
+
+describe('classifySseError (SSE error_type → user copy)', () => {
+  const sseCases: Array<{ errorType: string; expected: RegExp; retryable: boolean }> = [
+    { errorType: 'rate_limit_error', expected: /busy right now/i, retryable: true },
+    { errorType: 'capacity_error', expected: /at capacity/i, retryable: true },
+    { errorType: 'provider_error', expected: /model had a problem responding.*not charged/i, retryable: true },
+    { errorType: 'timeout_error', expected: /model had a problem responding.*not charged/i, retryable: true },
+    { errorType: 'not_found_error', expected: /isn't available/i, retryable: false },
+    { errorType: 'auth_error', expected: /credential|log(ging)? in|session/i, retryable: false },
+    { errorType: 'stream_error', expected: /something went wrong/i, retryable: true },
+  ];
+
+  it.each(sseCases)('maps $errorType', ({ errorType, expected, retryable }) => {
+    const err = classifySseError({ error_type: errorType, message: 'raw provider text with secrets' });
+    expect(getUserMessage(err)).toMatch(expected);
+    expect(getUserMessage(err)).not.toMatch(/raw provider text/);
+    expect(err.retryable).toBe(retryable);
+  });
+
+  it('falls back to generic copy for unknown error types', () => {
+    const err = classifySseError({ error_type: 'quantum_flux_error', message: 'exotic failure' });
+    expect(getUserMessage(err)).toMatch(/something went wrong/i);
+    expect(getUserMessage(err)).not.toMatch(/exotic failure/);
+    expect(err.retryable).toBe(true);
+  });
+
+  it('carries the request ID through as metadata', () => {
+    const err = classifySseError({ error_type: 'provider_error', request_id: 'req_sse1' });
+    expect(err.requestId).toBe('req_sse1');
+    expect(getUserMessage(err)).not.toMatch(/req_sse1/);
+  });
 });
 
 describe('parseErrorResponse', () => {
@@ -106,6 +317,19 @@ describe('parseErrorResponse', () => {
     );
     const err = await parseErrorResponse(response, 'fetching gateways');
     expect(getUserMessage(err)).toMatch(/20/);
+  });
+
+  it('reads X-RateLimit-Scope and X-Request-ID headers', async () => {
+    const response = mockResponse(
+      429,
+      { detail: 'Provider rate limited' },
+      { 'Retry-After': '15', 'X-RateLimit-Scope': 'upstream', 'X-Request-ID': 'req_hdr9' }
+    );
+    const err = await parseErrorResponse(response);
+    expect(err.rateLimitScope).toBe('upstream');
+    expect(err.retryAfterSeconds).toBe(15);
+    expect(err.requestId).toBe('req_hdr9');
+    expect(getUserMessage(err)).toMatch(/busy right now/i);
   });
 
   it('falls back gracefully when the body is not valid JSON', async () => {

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -28,6 +28,8 @@ export type ErrorCode =
   | 'API_VALIDATION_ERROR'
   | 'API_PAYMENT_REQUIRED'
   | 'API_RATE_LIMITED'
+  | 'API_UPSTREAM_RATE_LIMITED'
+  | 'SUBSCRIPTION_INACTIVE'
   // Chat errors
   | 'CHAT_SESSION_ERROR'
   | 'CHAT_MESSAGE_ERROR'
@@ -55,8 +57,10 @@ export const ERROR_MESSAGES: Record<ErrorCode, string> = {
   API_NOT_FOUND: 'The requested resource was not found.',
   API_SERVER_ERROR: 'Server error. Please try again later.',
   API_VALIDATION_ERROR: 'Invalid request. Please check your input.',
-  API_PAYMENT_REQUIRED: "You don't have enough credits for this request. Add credits to continue.",
+  API_PAYMENT_REQUIRED: "You don't have enough credits for this request.",
   API_RATE_LIMITED: "You're sending requests too quickly. Please wait a moment and try again.",
+  API_UPSTREAM_RATE_LIMITED: 'This model is busy right now — retrying shortly. You can also try another model.',
+  SUBSCRIPTION_INACTIVE: 'Your subscription is inactive. Renew it to keep using this feature.',
   // Chat
   CHAT_SESSION_ERROR: 'Failed to manage chat session.',
   CHAT_MESSAGE_ERROR: 'Failed to send message.',
@@ -79,12 +83,20 @@ export interface AppErrorDetails {
   originalError?: Error;
 }
 
+/** Which side enforced a 429: the model provider (upstream) or our gateway. */
+export type RateLimitScope = 'upstream' | 'gateway';
+
 export class AppError extends Error {
   readonly code: ErrorCode;
   readonly details?: Record<string, unknown>;
   readonly retryable: boolean;
   readonly timestamp: number;
   readonly originalError?: Error;
+  /** Backend request ID (X-Request-ID / body request_id) for support tracing. Safe to display as "Error ID". */
+  requestId?: string;
+  /** Seconds the client should wait before retrying (Retry-After). */
+  retryAfterSeconds?: number;
+  rateLimitScope?: RateLimitScope;
 
   constructor(
     code: ErrorCode,
@@ -93,6 +105,9 @@ export class AppError extends Error {
       details?: Record<string, unknown>;
       retryable?: boolean;
       originalError?: Error;
+      requestId?: string;
+      retryAfterSeconds?: number;
+      rateLimitScope?: RateLimitScope;
     }
   ) {
     super(message || ERROR_MESSAGES[code]);
@@ -102,6 +117,9 @@ export class AppError extends Error {
     this.retryable = options?.retryable ?? false;
     this.timestamp = Date.now();
     this.originalError = options?.originalError;
+    this.requestId = options?.requestId;
+    this.retryAfterSeconds = options?.retryAfterSeconds;
+    this.rateLimitScope = options?.rateLimitScope;
 
     // Maintain proper stack trace
     if (Error.captureStackTrace) {
@@ -159,25 +177,39 @@ export class NetworkError extends AppError {
   }
 }
 
+type ApiErrorCode = Extract<
+  ErrorCode,
+  | 'API_ERROR'
+  | 'API_NOT_FOUND'
+  | 'API_SERVER_ERROR'
+  | 'API_VALIDATION_ERROR'
+  | 'API_PAYMENT_REQUIRED'
+  | 'API_RATE_LIMITED'
+  | 'API_UPSTREAM_RATE_LIMITED'
+  | 'SUBSCRIPTION_INACTIVE'
+>;
+
 export class ApiError extends AppError {
   readonly statusCode?: number;
 
   constructor(
-    code: Extract<
-      ErrorCode,
-      'API_ERROR' | 'API_NOT_FOUND' | 'API_SERVER_ERROR' | 'API_VALIDATION_ERROR' | 'API_PAYMENT_REQUIRED' | 'API_RATE_LIMITED'
-    >,
+    code: ApiErrorCode,
     message?: string,
     options?: {
       details?: Record<string, unknown>;
       statusCode?: number;
       originalError?: Error;
       retryable?: boolean;
+      requestId?: string;
+      retryAfterSeconds?: number;
+      rateLimitScope?: RateLimitScope;
     }
   ) {
     super(code, message, {
       ...options,
-      retryable: options?.retryable ?? (code === 'API_SERVER_ERROR' || code === 'API_RATE_LIMITED'),
+      retryable:
+        options?.retryable ??
+        (code === 'API_SERVER_ERROR' || code === 'API_RATE_LIMITED' || code === 'API_UPSTREAM_RATE_LIMITED'),
     });
     this.name = 'ApiError';
     this.statusCode = options?.statusCode;
@@ -355,6 +387,20 @@ function formatRetryAfter(seconds?: number): string {
   return ` Try again in ${Math.round(seconds / 60)} min.`;
 }
 
+/** Human-friendly wait duration for rate-limit copy ("20 seconds", "5 minutes", "2 hours"). */
+function formatWaitDuration(seconds: number): string {
+  if (seconds < 60) {
+    const s = Math.max(1, Math.round(seconds));
+    return `${s} second${s === 1 ? '' : 's'}`;
+  }
+  if (seconds < 3600) {
+    const m = Math.round(seconds / 60);
+    return `${m} minute${m === 1 ? '' : 's'}`;
+  }
+  const h = Math.round(seconds / 3600);
+  return `${h} hour${h === 1 ? '' : 's'}`;
+}
+
 function statusToErrorCode(status: number): ErrorCode {
   if (status === 401) return 'AUTH_EXPIRED';
   if (status === 402) return 'API_PAYMENT_REQUIRED';
@@ -376,59 +422,153 @@ function buildFromCode(code: ErrorCode, message: string, statusCode?: number): A
   if (code === 'CHAT_SESSION_ERROR' || code === 'CHAT_MESSAGE_ERROR' || code === 'CHAT_STREAM_ERROR' || code === 'CHAT_MODEL_ERROR') {
     return new ChatError(code, message);
   }
-  return new ApiError(
-    code as Extract<
-      ErrorCode,
-      'API_ERROR' | 'API_NOT_FOUND' | 'API_SERVER_ERROR' | 'API_VALIDATION_ERROR' | 'API_PAYMENT_REQUIRED' | 'API_RATE_LIMITED'
-    >,
-    message,
-    { statusCode }
-  );
+  return new ApiError(code as ApiErrorCode, message, { statusCode });
+}
+
+/**
+ * Unwrap the envelope our Next.js proxy routes put around backend error bodies
+ * ({ error: 'Backend API Error', status, message, errorData: <backend body> })
+ * so classification sees the backend's own `error.code`/`error.type`.
+ */
+function unwrapProxyEnvelope(b: Record<string, unknown>): Record<string, unknown> {
+  const nested = b.errorData;
+  if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+    return nested as Record<string, unknown>;
+  }
+  return b;
+}
+
+function readRequestIdFromBody(b: Record<string, unknown>): string | undefined {
+  const direct = b.request_id ?? b.requestId;
+  if (typeof direct === 'string' && direct) return direct;
+  const errorField = b.error;
+  if (errorField && typeof errorField === 'object') {
+    const rid = (errorField as Record<string, unknown>).request_id;
+    if (typeof rid === 'string' && rid) return rid;
+  }
+  return undefined;
 }
 
 /**
  * Classify a parsed (or unparseable) backend error body + HTTP status into an
  * AppError with a specific, safe, user-facing message. Handles every shape
- * documented in the "Error response shape summary" audit finding.
+ * documented in the "Error response shape summary" audit finding, plus the
+ * newer contract: request IDs, X-RateLimit-Scope upstream/gateway 429s, and
+ * subscription_* 403 codes.
  */
 export function classifyApiError(
   status: number,
   body: unknown,
-  opts?: { retryAfter?: number; context?: string }
+  opts?: {
+    retryAfter?: number;
+    context?: string;
+    /** Value of the X-RateLimit-Scope response header, if any. */
+    rateLimitScope?: string | null;
+    /** Value of the X-Request-ID response header, if any. */
+    requestId?: string | null;
+  }
 ): AppError {
-  const b = (body ?? {}) as Record<string, unknown>;
+  const raw = (body ?? {}) as Record<string, unknown>;
+  const b = unwrapProxyEnvelope(raw);
   const errorField = b.error;
-  const retryAfter = opts?.retryAfter ?? readRetryAfterFromBody(b);
+  const retryAfter = opts?.retryAfter ?? readRetryAfterFromBody(b) ?? readRetryAfterFromBody(raw);
+  const requestId = opts?.requestId ?? readRequestIdFromBody(b) ?? readRequestIdFromBody(raw);
+  const rateLimitScope: RateLimitScope | undefined =
+    status === 429 ? (opts?.rateLimitScope?.toLowerCase() === 'upstream' ? 'upstream' : 'gateway') : undefined;
 
-  // Shapes 1 & 2: `error` is an object, possibly with a known `code`.
-  if (errorField && typeof errorField === 'object') {
-    const errorObj = errorField as Record<string, unknown>;
-    const code = typeof errorObj.code === 'string' ? errorObj.code : undefined;
-    if (code && BACKEND_CODE_MESSAGES[code]) {
-      const bucket = BACKEND_CODE_TO_BUCKET[code];
-      const suffix = code === 'RATE_LIMIT_EXCEEDED' || code === 'DAILY_QUOTA_EXCEEDED' || code === 'TOKEN_RATE_LIMIT'
-        ? formatRetryAfter(retryAfter)
-        : '';
-      return buildFromCode(bucket?.code ?? statusToErrorCode(status), BACKEND_CODE_MESSAGES[code] + suffix, status);
+  const errorObj = errorField && typeof errorField === 'object' ? (errorField as Record<string, unknown>) : undefined;
+  const backendCode = errorObj && typeof errorObj.code === 'string' ? errorObj.code : undefined;
+  const backendType = errorObj && typeof errorObj.type === 'string' ? errorObj.type : undefined;
+
+  const finalize = (err: AppError): AppError => {
+    if (requestId) err.requestId = requestId;
+    if (retryAfter !== undefined && retryAfter > 0) err.retryAfterSeconds = retryAfter;
+    if (rateLimitScope) err.rateLimitScope = rateLimitScope;
+    return err;
+  };
+
+  // 429 — who enforced the limit decides the copy: an upstream (model provider)
+  // limit is not the user's fault and gets model-busy copy; a gateway limit
+  // means the user should slow down.
+  if (status === 429) {
+    if (rateLimitScope === 'upstream') {
+      return finalize(
+        new ApiError('API_UPSTREAM_RATE_LIMITED', ERROR_MESSAGES.API_UPSTREAM_RATE_LIMITED, { statusCode: status })
+      );
+    }
+    // Quota-style gateway limits keep their more specific copy. The code can
+    // be nested (error.code) or top-level (guest rate-limit responses).
+    const rateCode = (
+      (errorObj && typeof errorObj.code === 'string' && errorObj.code) ||
+      (typeof b.code === 'string' && b.code) ||
+      ''
+    ).toUpperCase();
+    if (rateCode === 'GUEST_RATE_LIMIT_EXCEEDED') {
+      return finalize(
+        new ApiError(
+          'API_RATE_LIMITED',
+          "You've used all your free messages for today. Sign up for a free account to continue chatting!",
+          { statusCode: status }
+        )
+      );
+    }
+    if ((rateCode === 'DAILY_QUOTA_EXCEEDED' || rateCode === 'TOKEN_RATE_LIMIT' || rateCode === 'PLAN_LIMIT_REACHED') && BACKEND_CODE_MESSAGES[rateCode]) {
+      return finalize(
+        new ApiError('API_RATE_LIMITED', BACKEND_CODE_MESSAGES[rateCode] + formatRetryAfter(retryAfter), { statusCode: status })
+      );
+    }
+    const message =
+      retryAfter && retryAfter > 0
+        ? `You're sending requests too quickly. Please wait ${formatWaitDuration(retryAfter)} and try again.`
+        : ERROR_MESSAGES.API_RATE_LIMITED;
+    return finalize(new ApiError('API_RATE_LIMITED', message, { statusCode: status }));
+  }
+
+  // 402 — insufficient credits. The UI attaches an "Add credits" CTA to this code.
+  if (status === 402) {
+    return finalize(new ApiError('API_PAYMENT_REQUIRED', ERROR_MESSAGES.API_PAYMENT_REQUIRED, { statusCode: status }));
+  }
+
+  // 403 with a subscription_* code — inactive subscription. The UI attaches a "Renew" CTA.
+  const codeOrType = (backendCode ?? backendType ?? '').toLowerCase();
+  if (status === 403 && codeOrType.startsWith('subscription_')) {
+    return finalize(new ApiError('SUBSCRIPTION_INACTIVE', ERROR_MESSAGES.SUBSCRIPTION_INACTIVE, { statusCode: status }));
+  }
+
+  // Shapes 1 & 2: `error` is an object, possibly with a known `code` (the
+  // backend emits both UPPER_SNAKE and lower_snake variants — normalize).
+  if (errorObj) {
+    const normalizedCode = backendCode?.toUpperCase();
+    if (normalizedCode && BACKEND_CODE_MESSAGES[normalizedCode]) {
+      const bucket = BACKEND_CODE_TO_BUCKET[normalizedCode];
+      const suffix =
+        normalizedCode === 'RATE_LIMIT_EXCEEDED' || normalizedCode === 'DAILY_QUOTA_EXCEEDED' || normalizedCode === 'TOKEN_RATE_LIMIT'
+          ? formatRetryAfter(retryAfter)
+          : '';
+      return finalize(
+        buildFromCode(bucket?.code ?? statusToErrorCode(status), BACKEND_CODE_MESSAGES[normalizedCode] + suffix, status)
+      );
     }
     // No recognized code — fall back to status-based classification.
-    return buildFromCode(statusToErrorCode(status), ERROR_MESSAGES[statusToErrorCode(status)] + formatRetryAfter(retryAfter), status);
+    return finalize(
+      buildFromCode(statusToErrorCode(status), ERROR_MESSAGES[statusToErrorCode(status)] + formatRetryAfter(retryAfter), status)
+    );
   }
 
   // Shape 3: `error` is a bare string (api_keys.py / auth.py 429 variant).
   if (typeof errorField === 'string') {
     const code = statusToErrorCode(status);
-    return buildFromCode(code, ERROR_MESSAGES[code] + formatRetryAfter(retryAfter), status);
+    return finalize(buildFromCode(code, ERROR_MESSAGES[code] + formatRetryAfter(retryAfter), status));
   }
 
   // Shape 4: untouched FastAPI 422 default — `detail` is an array of field errors.
   if (Array.isArray(b.detail)) {
-    return buildFromCode('API_VALIDATION_ERROR', ERROR_MESSAGES.API_VALIDATION_ERROR, status);
+    return finalize(buildFromCode('API_VALIDATION_ERROR', ERROR_MESSAGES.API_VALIDATION_ERROR, status));
   }
 
   // Shape 5 / unrecognized body / no body at all — classify by status only.
   const code = statusToErrorCode(status);
-  return buildFromCode(code, ERROR_MESSAGES[code] + formatRetryAfter(retryAfter), status);
+  return finalize(buildFromCode(code, ERROR_MESSAGES[code] + formatRetryAfter(retryAfter), status));
 }
 
 function readRetryAfterFromBody(b: Record<string, unknown>): number | undefined {
@@ -466,8 +606,89 @@ export async function parseErrorResponse(response: Response, context?: string): 
 
   return classifyApiError(response.status, body, {
     retryAfter: Number.isFinite(retryAfter) ? retryAfter : undefined,
+    rateLimitScope: response.headers?.get?.('X-RateLimit-Scope'),
+    requestId: response.headers?.get?.('X-Request-ID'),
     context,
   });
+}
+
+// =============================================================================
+// SSE STREAM ERROR CLASSIFICATION
+// =============================================================================
+
+/**
+ * Friendly copy for the backend's SSE error chunk `error_type` values
+ * (chat_streaming.py). Raw chunk text is never surfaced — only this copy.
+ */
+const SSE_ERROR_TYPE_MAP: Record<string, { code: ErrorCode; message: string; retryable: boolean }> = {
+  rate_limit_error: {
+    code: 'API_UPSTREAM_RATE_LIMITED',
+    message: 'This model is busy right now. Please try again shortly, or switch to another model.',
+    retryable: true,
+  },
+  capacity_error: {
+    code: 'CHAT_MODEL_ERROR',
+    message: 'This model is at capacity right now. Please try again shortly, or switch to another model.',
+    retryable: true,
+  },
+  provider_error: {
+    code: 'CHAT_STREAM_ERROR',
+    message: 'The model had a problem responding. Your credits for this message were not charged — try again.',
+    retryable: true,
+  },
+  timeout_error: {
+    code: 'CHAT_STREAM_ERROR',
+    message: 'The model had a problem responding. Your credits for this message were not charged — try again.',
+    retryable: true,
+  },
+  not_found_error: {
+    code: 'API_NOT_FOUND',
+    message: "That model isn't available. Please choose a different model.",
+    retryable: false,
+  },
+  auth_error: {
+    code: 'AUTH_INVALID',
+    message: ERROR_MESSAGES.AUTH_INVALID,
+    retryable: false,
+  },
+  stream_error: {
+    code: 'CHAT_STREAM_ERROR',
+    message: 'Something went wrong. Please try again.',
+    retryable: true,
+  },
+};
+
+/**
+ * Classify an SSE error chunk into an AppError with safe user-facing copy.
+ * Accepts the backend's `error_type` field as well as legacy `type`/`code`
+ * variants; anything unrecognized gets the generic retryable message.
+ */
+export function classifySseError(chunk: {
+  error_type?: string;
+  type?: string;
+  code?: string;
+  message?: string;
+  request_id?: string;
+}): AppError {
+  const key = (chunk.error_type || chunk.type || chunk.code || '').toLowerCase();
+  const mapped = SSE_ERROR_TYPE_MAP[key];
+
+  const entry = mapped ?? {
+    code: 'CHAT_STREAM_ERROR' as ErrorCode,
+    message: 'Something went wrong. Please try again.',
+    retryable: true,
+  };
+
+  let err: AppError;
+  if (entry.code === 'AUTH_INVALID') {
+    err = new AuthError('AUTH_INVALID', entry.message);
+  } else if (entry.code === 'CHAT_STREAM_ERROR' || entry.code === 'CHAT_MODEL_ERROR') {
+    err = new ChatError(entry.code, entry.message, { retryable: entry.retryable });
+  } else {
+    err = new ApiError(entry.code as ApiErrorCode, entry.message, { retryable: entry.retryable });
+  }
+  if (chunk.request_id) err.requestId = chunk.request_id;
+  return err;
 }
 
 /**
@@ -480,7 +701,15 @@ export function fromStreamingError(error: {
   code?: string;
   retryable?: boolean;
   retryAfterMs?: number;
+  appError?: unknown;
 }): AppError {
+  // The streaming layer attaches the already-classified AppError when it ran
+  // classification at the HTTP/SSE boundary — use it directly so specific
+  // copy and metadata (requestId, retry-after, rate-limit scope) survive.
+  if (error.appError instanceof AppError) {
+    return error.appError;
+  }
+
   switch (error.code) {
     case 'AUTH_ERROR':
       return new AuthError('AUTH_INVALID', ERROR_MESSAGES.AUTH_INVALID);

--- a/src/lib/hooks/use-chat-stream.ts
+++ b/src/lib/hooks/use-chat-stream.ts
@@ -11,6 +11,7 @@ import { ModelOption } from '@/components/chat/model-select';
 import { ChatMessage } from '@/lib/chat-history';
 import { sentryMetrics } from '@/lib/sentry-metrics';
 import { isTauriEnvironment } from '@/lib/config';
+import { fromUnknown, getUserMessage } from '@/lib/errors';
 
 // Stream stopped error for clean cancellation
 class StreamStoppedError extends Error {
@@ -422,6 +423,25 @@ export function useChatStream() {
                     break;
                 }
 
+                // Rate-limit retry in progress: surface a countdown notice on the
+                // streaming assistant message (e.g. "model busy — retrying in Ns")
+                if (chunk.status === 'rate_limit_retry') {
+                    const retryNotice = {
+                        scope: chunk.rateLimitScope ?? 'gateway',
+                        retryAfterMs: chunk.retryAfterMs ?? 0,
+                        startedAt: Date.now(),
+                    };
+                    flushSync(() => {
+                        queryClient.setQueryData(['chat-messages', sessionId], (old: any[] | undefined) => {
+                            if (!old || old.length === 0) return old || [];
+                            const last = old[old.length - 1];
+                            if (!last || last.role !== 'assistant') return old;
+                            return [...old.slice(0, -1), { ...last, retryNotice }];
+                        });
+                    });
+                    continue;
+                }
+
                 chunkCount++;
 
                 if (chunkCount === 1) {
@@ -473,6 +493,7 @@ export function useChatStream() {
                                 reasoning: currentReasoning,
                                 isReasoningStreaming,
                                 isStreaming: true, // Ensure streaming flag stays true during updates
+                                retryNotice: undefined, // Content arrived — clear any rate-limit countdown
                             }];
                         });
                     });
@@ -597,21 +618,23 @@ export function useChatStream() {
                 stack: e instanceof Error ? e.stack : undefined
             });
             console.error("Streaming failed", e);
-            const errorMessage = e instanceof Error ? e.message : "Failed to complete response";
-            setStreamError(errorMessage);
+
+            // Classify into safe, user-facing copy + structured metadata. Raw
+            // error text was already sent to telemetry by the streaming layer
+            // and must never reach the screen.
+            const appError = fromUnknown(e);
+            const safeMessage = getUserMessage(appError);
+            setStreamError(safeMessage);
 
             // Track chat error with Sentry
             const provider = model.sourceGateway || 'unknown';
-            const errorType = e instanceof TypeError ? 'network' :
-                             e instanceof Error && e.message.includes('timeout') ? 'timeout' :
-                             e instanceof Error && e.message.includes('401') ? 'auth' :
-                             e instanceof Error && e.message.includes('429') ? 'rate_limit' :
-                             'stream_error';
-            sentryMetrics.trackChatError(model.value, provider, errorType, {
+            sentryMetrics.trackChatError(model.value, provider, appError.code.toLowerCase(), {
                 is_streaming: 'true'
             });
 
-            // Mark the assistant message as failed with error metadata, not appended to content
+            // Mark the assistant message as failed with error metadata, not appended
+            // to content. Partial streamed content stays visible — the error renders
+            // as a non-blocking notice below it.
             flushSync(() => {
                 queryClient.setQueryData(['chat-messages', sessionId], (old: any[] | undefined) => {
                     if (!old || old.length === 0) return old || [];
@@ -622,8 +645,16 @@ export function useChatStream() {
                         ...last,
                         content: last.content || '', // Keep existing content if any
                         isStreaming: false,
-                        error: errorMessage, // Store error separately, not in content
-                        hasError: true
+                        retryNotice: undefined,
+                        error: safeMessage, // Friendly copy only — never raw error text
+                        hasError: true,
+                        errorInfo: {
+                            code: appError.code,
+                            retryable: appError.retryable,
+                            requestId: appError.requestId,
+                            retryAfterSeconds: appError.retryAfterSeconds,
+                            rateLimitScope: appError.rateLimitScope,
+                        },
                     }];
                 });
             });

--- a/src/lib/streaming/__tests__/sse-parser.test.ts
+++ b/src/lib/streaming/__tests__/sse-parser.test.ts
@@ -231,23 +231,23 @@ describe('parseSSEChunk', () => {
       expect(() => parseSSEChunk(json)).toThrow(StreamingError);
     });
 
-    it('should handle response.error event with message at top level (line 240)', () => {
-      // Line 240: use data.message when error.message is not present
+    it('should handle response.error event without leaking the raw top-level message', () => {
       const json = JSON.stringify({
         type: 'response.error',
         message: 'Top level error message',
       });
       expect(() => parseSSEChunk(json)).toThrow(StreamingError);
-      expect(() => parseSSEChunk(json)).toThrow('Top level error message');
+      // Raw provider text must never surface in the user-facing message
+      expect(() => parseSSEChunk(json)).not.toThrow('Top level error message');
+      expect(() => parseSSEChunk(json)).toThrow(/something went wrong/i);
     });
 
-    it('should handle response.error event with default message (line 241)', () => {
-      // Line 241: default message when no specific message found
+    it('should handle response.error event with generic friendly copy', () => {
       const json = JSON.stringify({
         type: 'response.error',
       });
       expect(() => parseSSEChunk(json)).toThrow(StreamingError);
-      expect(() => parseSSEChunk(json)).toThrow('Response stream error');
+      expect(() => parseSSEChunk(json)).toThrow(/something went wrong/i);
     });
 
     it('should return null for unknown event types', () => {
@@ -261,12 +261,13 @@ describe('parseSSEChunk', () => {
   });
 
   describe('Error handling', () => {
-    it('should throw StreamingError for error objects', () => {
+    it('should throw StreamingError with friendly copy, never the raw provider message', () => {
       const json = JSON.stringify({
-        error: { message: 'Model unavailable' },
+        error: { message: 'ProviderXYZ backend exploded at line 42' },
       });
       expect(() => parseSSEChunk(json)).toThrow(StreamingError);
-      expect(() => parseSSEChunk(json)).toThrow('Model unavailable');
+      expect(() => parseSSEChunk(json)).not.toThrow(/ProviderXYZ|line 42/);
+      expect(() => parseSSEChunk(json)).toThrow(/something went wrong/i);
     });
 
     it('should handle trial expired errors', () => {
@@ -276,32 +277,33 @@ describe('parseSSEChunk', () => {
       expect(() => parseSSEChunk(json)).toThrow(/FREE models/);
     });
 
-    it('should handle upstream rejected errors', () => {
+    it('should handle upstream rejected errors as a provider problem (no raw text)', () => {
       const json = JSON.stringify({
         error: { message: 'upstream rejected the request' },
       });
-      expect(() => parseSSEChunk(json)).toThrow(/Backend error/);
+      expect(() => parseSSEChunk(json)).toThrow(/model had a problem responding/i);
+      expect(() => parseSSEChunk(json)).not.toThrow(/upstream rejected/);
     });
 
     it('should handle rate limit errors by code', () => {
       const json = JSON.stringify({
         error: { code: 'rate_limit_exceeded' },
       });
-      expect(() => parseSSEChunk(json)).toThrow(/Rate limit exceeded/);
+      expect(() => parseSSEChunk(json)).toThrow(/busy right now/i);
     });
 
     it('should handle rate limit errors by type', () => {
       const json = JSON.stringify({
         error: { type: 'rate_limit', message: 'Too many requests' },
       });
-      expect(() => parseSSEChunk(json)).toThrow(/Rate limit exceeded/);
+      expect(() => parseSSEChunk(json)).toThrow(/busy right now/i);
     });
 
     it('should handle rate limit errors by status 429', () => {
       const json = JSON.stringify({
         error: { status: 429, message: 'Slow down' },
       });
-      expect(() => parseSSEChunk(json)).toThrow(/Rate limit exceeded/);
+      expect(() => parseSSEChunk(json)).toThrow(/busy right now/i);
     });
 
     it('should return null for unparseable JSON', () => {
@@ -319,27 +321,29 @@ describe('parseSSEChunk', () => {
       expect(result?.content).toBe('Hello');
     });
 
-    it('should handle string error (line 308-309)', () => {
-      // Lines 308-309: handle error as string
+    it('should handle string error without echoing the raw string', () => {
       const json = JSON.stringify({
         error: 'Simple string error message',
       });
-      expect(() => parseSSEChunk(json)).toThrow('Stream error: Simple string error message');
+      expect(() => parseSSEChunk(json)).toThrow(StreamingError);
+      expect(() => parseSSEChunk(json)).not.toThrow(/Simple string error message/);
+      expect(() => parseSSEChunk(json)).toThrow(/something went wrong/i);
     });
 
-    it('should handle unusual error types (lines 312-313)', () => {
-      // Lines 312-313: handle error that is neither object nor string
+    it('should handle unusual error types with generic copy', () => {
       const json = JSON.stringify({
         error: 12345,
       });
-      expect(() => parseSSEChunk(json)).toThrow('Stream error: 12345');
+      expect(() => parseSSEChunk(json)).toThrow(StreamingError);
+      expect(() => parseSSEChunk(json)).toThrow(/something went wrong/i);
     });
 
     it('should handle boolean error value', () => {
       const json = JSON.stringify({
         error: true,
       });
-      expect(() => parseSSEChunk(json)).toThrow('Stream error: true');
+      expect(() => parseSSEChunk(json)).toThrow(StreamingError);
+      expect(() => parseSSEChunk(json)).toThrow(/something went wrong/i);
     });
 
     it('should handle array error value', () => {

--- a/src/lib/streaming/__tests__/stream-chat.test.ts
+++ b/src/lib/streaming/__tests__/stream-chat.test.ts
@@ -291,12 +291,12 @@ describe('streamChatResponse', () => {
       expect((thrown as Error).message).not.toContain('session has expired');
     });
 
-    it('should throw StreamingError on 404 model not found', async () => {
+    it('should throw a friendly model-unavailable message on 404 without raw detail', async () => {
       global.fetch = jest.fn().mockResolvedValueOnce({
         ok: false,
         status: 404,
         headers: new Headers(),
-        json: jest.fn().mockResolvedValue({ detail: 'Model not found' }),
+        json: jest.fn().mockResolvedValue({ detail: "Model 'internal-slug-v3' not found in registry" }),
       });
 
       const generator = streamChatResponse(
@@ -305,7 +305,15 @@ describe('streamChatResponse', () => {
         { model: 'nonexistent-model', messages: [] }
       );
 
-      await expect(collectChunks(generator)).rejects.toThrow(/Model not found/);
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(StreamingError);
+      expect((thrown as Error).message).toMatch(/model isn't available/i);
+      expect((thrown as Error).message).not.toContain('internal-slug-v3');
     });
 
     it('should throw StreamingError on 413 payload too large', async () => {
@@ -378,6 +386,189 @@ describe('streamChatResponse', () => {
       );
 
       await expect(collectChunks(generator)).rejects.toThrow(RateLimitError);
+    });
+
+    it('gateway 429 (no upstream scope) surfaces "wait N seconds" copy, not model-busy copy', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: new Headers({ 'Retry-After': '30' }),
+        json: jest.fn().mockResolvedValue({ detail: 'Rate limited' }),
+      });
+
+      const generator = streamChatResponse(
+        'https://api.test.com/v1/chat/completions',
+        'test-api-key',
+        { model: 'gpt-4', messages: [] },
+        7, // Already at max retries — throws immediately
+        7
+      );
+
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(RateLimitError);
+      expect((thrown as RateLimitError).rateLimitScope).toBe('gateway');
+      expect((thrown as Error).message).toMatch(/too quickly/i);
+      expect((thrown as Error).message).toMatch(/30/);
+      expect((thrown as Error).message).not.toMatch(/busy right now/i);
+    });
+
+    it('upstream 429 (X-RateLimit-Scope: upstream) auto-retries once after Retry-After with a countdown chunk', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          headers: new Headers({ 'Retry-After': '1', 'X-RateLimit-Scope': 'upstream' }),
+          json: jest.fn().mockResolvedValue({ detail: 'Provider rate limited' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          body: createSSEResponse([
+            JSON.stringify({ choices: [{ delta: { content: 'Recovered' }, finish_reason: null }] }),
+            JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] }),
+          ]),
+        });
+
+      const generator = streamChatResponse(
+        'https://api.test.com/v1/chat/completions',
+        'test-api-key',
+        { model: 'free-model', messages: [] },
+        0,
+        7
+      );
+
+      const chunks = await collectChunks(generator);
+      const retryChunk = chunks.find((c) => c.status === 'rate_limit_retry');
+      expect(retryChunk).toBeDefined();
+      expect(retryChunk?.rateLimitScope).toBe('upstream');
+      expect(retryChunk?.retryAfterMs).toBeGreaterThanOrEqual(1000);
+      expect(chunks.find((c) => c.content)?.content).toBe('Recovered');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    }, 15000);
+
+    it('upstream 429 retries only ONCE, then throws model-busy copy (never "your limit")', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: new Headers({ 'Retry-After': '1', 'X-RateLimit-Scope': 'upstream' }),
+        json: jest.fn().mockResolvedValue({ detail: 'Provider rate limited' }),
+      });
+
+      const generator = streamChatResponse(
+        'https://api.test.com/v1/chat/completions',
+        'test-api-key',
+        { model: 'free-model', messages: [] },
+        0,
+        7
+      );
+
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(RateLimitError);
+      expect((thrown as RateLimitError).rateLimitScope).toBe('upstream');
+      expect((thrown as Error).message).toMatch(/busy right now/i);
+      expect((thrown as Error).message).not.toMatch(/too quickly|your.*limit/i);
+      // Exactly one auto-retry: original attempt + one retry
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    }, 15000);
+
+    it('surfaces the request ID on 500 errors for support tracing', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        json: jest.fn().mockResolvedValue({
+          error: {
+            code: 'INTERNAL_ERROR',
+            message: 'Internal server error (request ID: req_xyz789)',
+            request_id: 'req_xyz789',
+          },
+        }),
+      });
+
+      const generator = streamChatResponse(
+        'https://api.test.com/v1/chat/completions',
+        'test-api-key',
+        { model: 'gpt-4', messages: [] }
+      );
+
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(StreamingError);
+      expect((thrown as StreamingError).requestId).toBe('req_xyz789');
+      // Message is friendly copy; the raw request-ID string is metadata, not copy
+      expect((thrown as Error).message).not.toMatch(/req_xyz789/);
+    });
+
+    it('maps a subscription_* 403 to inactive-subscription copy', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        headers: new Headers(),
+        json: jest.fn().mockResolvedValue({
+          error: { code: 'subscription_canceled', message: 'Subscription sub_123 was canceled on 2026-06-01' },
+        }),
+      });
+
+      const generator = streamChatResponse(
+        'https://api.test.com/v1/chat/completions',
+        'test-api-key',
+        { model: 'gpt-4', messages: [] }
+      );
+
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(StreamingError);
+      expect((thrown as StreamingError).code).toBe('SUBSCRIPTION_INACTIVE');
+      expect((thrown as Error).message).toMatch(/subscription is inactive/i);
+      expect((thrown as Error).message).not.toContain('sub_123');
+    });
+
+    it('maps 402 to insufficient-credits copy without echoing the backend detail', async () => {
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        headers: new Headers(),
+        json: jest.fn().mockResolvedValue({
+          detail: 'Insufficient credits. Required: $2.00, Current: $0.13',
+        }),
+      });
+
+      const generator = streamChatResponse(
+        'https://api.test.com/v1/chat/completions',
+        'test-api-key',
+        { model: 'gpt-4', messages: [] }
+      );
+
+      let thrown: unknown;
+      try {
+        await collectChunks(generator);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(StreamingError);
+      expect((thrown as StreamingError).code).toBe('API_PAYMENT_REQUIRED');
+      expect((thrown as Error).message).toMatch(/enough credits/i);
+      expect((thrown as Error).message).not.toContain('$2.00');
     });
 
     it('should throw StreamingError on 500 server error', async () => {

--- a/src/lib/streaming/errors.ts
+++ b/src/lib/streaming/errors.ts
@@ -2,7 +2,14 @@
  * Streaming Errors
  *
  * Custom error classes for streaming operations.
+ *
+ * IMPORTANT: `message` on these errors is displayed to users. It must always
+ * be safe, friendly copy — never raw backend text, provider payloads, stack
+ * traces, or JSON. Raw error details belong in telemetry (Sentry) and may be
+ * attached via the structured fields below for logging only.
  */
+
+import type { AppError, RateLimitScope } from '@/lib/errors';
 
 /**
  * Error thrown during stream processing that should be displayed to the user.
@@ -12,6 +19,19 @@ export class StreamingError extends Error {
   public readonly code?: string;
   public readonly type?: string;
   public readonly retryable: boolean;
+  /** Backend request ID for support tracing (safe to display as "Error ID"). */
+  public readonly requestId?: string;
+  /** Seconds the client should wait before retrying (from Retry-After). */
+  public readonly retryAfterSeconds?: number;
+  public readonly rateLimitScope?: RateLimitScope;
+  /** Raw provider/backend error text — telemetry only, never render. */
+  public readonly rawDetail?: string;
+  /**
+   * The classified AppError this streaming error was derived from, when the
+   * HTTP/SSE layer already ran classification. `fromStreamingError` returns
+   * this directly so no copy/metadata is lost on the way to the UI.
+   */
+  public readonly appError?: AppError;
 
   constructor(
     message: string,
@@ -19,6 +39,11 @@ export class StreamingError extends Error {
       code?: string;
       type?: string;
       retryable?: boolean;
+      requestId?: string;
+      retryAfterSeconds?: number;
+      rateLimitScope?: RateLimitScope;
+      rawDetail?: string;
+      appError?: AppError;
     }
   ) {
     super(message);
@@ -26,6 +51,11 @@ export class StreamingError extends Error {
     this.code = options?.code;
     this.type = options?.type;
     this.retryable = options?.retryable ?? false;
+    this.requestId = options?.requestId;
+    this.retryAfterSeconds = options?.retryAfterSeconds;
+    this.rateLimitScope = options?.rateLimitScope;
+    this.rawDetail = options?.rawDetail;
+    this.appError = options?.appError;
   }
 }
 
@@ -45,8 +75,20 @@ export class AuthenticationError extends StreamingError {
 export class RateLimitError extends StreamingError {
   public readonly retryAfterMs?: number;
 
-  constructor(message: string, retryAfterMs?: number) {
-    super(message, { code: 'RATE_LIMIT', type: 'rate_limit', retryable: true });
+  constructor(
+    message: string,
+    retryAfterMs?: number,
+    options?: { rateLimitScope?: RateLimitScope; requestId?: string; appError?: AppError }
+  ) {
+    super(message, {
+      code: 'RATE_LIMIT',
+      type: 'rate_limit',
+      retryable: true,
+      requestId: options?.requestId,
+      retryAfterSeconds: retryAfterMs !== undefined ? retryAfterMs / 1000 : undefined,
+      rateLimitScope: options?.rateLimitScope,
+      appError: options?.appError,
+    });
     this.name = 'RateLimitError';
     this.retryAfterMs = retryAfterMs;
   }

--- a/src/lib/streaming/sse-parser.ts
+++ b/src/lib/streaming/sse-parser.ts
@@ -7,6 +7,7 @@
 
 import type { ParsedSSEData } from './types';
 import { StreamingError } from './errors';
+import { classifySseError } from '@/lib/errors';
 
 /**
  * Convert various input types to plain text.
@@ -84,26 +85,31 @@ function extractContent(data: Record<string, unknown>): string {
 }
 
 /**
- * Extract error information from response data.
- * Handles various error formats from different providers.
+ * Extract error information from response data for internal classification and
+ * telemetry. `rawMessage` is NEVER shown to the user — display copy comes from
+ * classifySseError / the mapped messages in checkForError.
  */
-function extractError(errorObj: Record<string, unknown>): { message: string; type?: string; code?: string } {
-  // Try multiple common error message formats
-  const message =
+function extractErrorInfo(errorObj: Record<string, unknown>): {
+  rawMessage: string;
+  type?: string;
+  code?: string;
+  errorType?: string;
+  requestId?: string;
+} {
+  const rawMessage =
     (typeof errorObj.message === 'string' && errorObj.message) ||
     (typeof errorObj.detail === 'string' && errorObj.detail) ||
     (typeof errorObj.error === 'string' && errorObj.error) ||
     (typeof errorObj.text === 'string' && errorObj.text) ||
     (typeof errorObj.reason === 'string' && errorObj.reason) ||
-    (errorObj.code && errorObj.type ? `${errorObj.type}: ${errorObj.code}` : null) ||
-    (typeof errorObj.code === 'string' && `Error code: ${errorObj.code}`) ||
-    (typeof errorObj.type === 'string' && `Error type: ${errorObj.type}`) ||
-    `Stream error: ${JSON.stringify(errorObj)}`;
+    JSON.stringify(errorObj);
 
   return {
-    message,
+    rawMessage,
     type: typeof errorObj.type === 'string' ? errorObj.type : undefined,
     code: typeof errorObj.code === 'string' ? errorObj.code : undefined,
+    errorType: typeof errorObj.error_type === 'string' ? errorObj.error_type : undefined,
+    requestId: typeof errorObj.request_id === 'string' ? errorObj.request_id : undefined,
   };
 }
 
@@ -275,12 +281,21 @@ function parseEventFormat(data: Record<string, unknown>): ParsedSSEData | null {
     // Error events - these should propagate as errors, not regular returns
     case 'response.error': {
       const errorData = data.error as Record<string, unknown> | undefined;
-      const message =
-        (errorData && typeof errorData.message === 'string' && errorData.message) ||
-        (typeof data.message === 'string' && data.message) ||
-        'Response stream error';
-      // Throw immediately for response.error events so they're handled as stream errors
-      throw new StreamingError(message, { type: 'response_error' });
+      const info = errorData ? extractErrorInfo(errorData) : undefined;
+      const appError = classifySseError({
+        error_type: info?.errorType || (typeof data.error_type === 'string' ? data.error_type : 'stream_error'),
+        request_id: info?.requestId,
+      });
+      // Throw immediately for response.error events so they're handled as
+      // stream errors. Message is our friendly copy; raw text goes to telemetry.
+      throw new StreamingError(appError.getUserMessage(), {
+        type: 'response_error',
+        code: info?.code,
+        retryable: appError.retryable,
+        requestId: info?.requestId,
+        rawDetail: info?.rawMessage ?? (typeof data.message === 'string' ? data.message : undefined),
+        appError,
+      });
     }
 
     default:
@@ -289,86 +304,114 @@ function parseEventFormat(data: Record<string, unknown>): ParsedSSEData | null {
 }
 
 /**
+ * The backend streaming path's documented SSE error_type values
+ * (chat_streaming.py). Each maps to dedicated friendly copy in
+ * classifySseError — anything else falls back to generic copy.
+ */
+const KNOWN_SSE_ERROR_TYPES = new Set([
+  'rate_limit_error',
+  'capacity_error',
+  'provider_error',
+  'timeout_error',
+  'not_found_error',
+  'auth_error',
+  'stream_error',
+]);
+
+/** Build the safe error payload for a ParsedSSEData from a classified AppError. */
+function toSafeError(
+  appError: ReturnType<typeof classifySseError>,
+  info: { type?: string; code?: string; requestId?: string; rawMessage?: string }
+): ParsedSSEData {
+  return {
+    error: {
+      message: appError.getUserMessage(),
+      type: info.type,
+      code: info.code,
+      requestId: info.requestId ?? appError.requestId,
+      retryable: appError.retryable,
+      rawDetail: info.rawMessage,
+      appError,
+    },
+  };
+}
+
+/**
  * Check for error objects in the response data.
  * Only checks explicit error fields to avoid false positives with legitimate content fields.
+ *
+ * The returned `error.message` is always our own friendly copy — raw
+ * provider/backend text only travels in `error.rawDetail` for telemetry.
  */
 function checkForError(data: Record<string, unknown>): ParsedSSEData | null {
-  // Only check for explicit error object - don't treat top-level 'message' as error
-  // since some providers use 'message' for legitimate content
-  if (!data.error) return null;
+  const topLevelErrorType = typeof data.error_type === 'string' ? data.error_type : undefined;
 
-  // Handle nested error object
-  if (typeof data.error === 'object') {
-    const errorObj = data.error as Record<string, unknown>;
-    const errorInfo = extractError(errorObj);
+  // Only treat explicit error fields as errors - don't treat top-level 'message'
+  // as an error since some providers use 'message' for legitimate content
+  if (!data.error && !topLevelErrorType) return null;
 
-    // Check for known error patterns
-    const lowerMessage = errorInfo.message.toLowerCase();
-    const errorCode = (errorInfo.code || '').toLowerCase();
-    const errorType = (errorInfo.type || '').toLowerCase();
-
-    // Check for rate limit errors
-    if (
-      errorCode.includes('rate_limit') ||
-      errorType.includes('rate_limit') ||
-      lowerMessage.includes('rate limit') ||
-      lowerMessage.includes('too many requests') ||
-      errorObj.status === 429
-    ) {
-      return {
-        error: {
-          message: 'Rate limit exceeded. The model is temporarily unavailable due to high demand. Please try again in a moment.',
-          type: 'rate_limit',
-          code: errorInfo.code || 'rate_limit_exceeded',
-        },
-      };
-    }
-
-    if (lowerMessage.includes('trial has expired') || lowerMessage.includes('insufficient credits')) {
-      return {
-        error: {
-          message: 'Trial credits have been used up. You can still use FREE models! Look for models with the "FREE" badge, or add credits to use premium models.',
-          type: 'credits_exhausted',
-        },
-      };
-    }
-
-    if (lowerMessage.includes('upstream rejected')) {
-      return {
-        error: {
-          message: `Backend error: ${errorInfo.message}. This may be a temporary issue. Please try again or select a different model.`,
-          type: 'upstream_error',
-        },
-      };
-    }
-
-    // Check for "Not Found" / 404 errors — typically means the model doesn't exist
-    if (
-      lowerMessage === 'not found' ||
-      lowerMessage.includes('model not found') ||
-      lowerMessage.includes('no such model') ||
-      errorCode === '404' ||
-      errorObj.status === 404
-    ) {
-      return {
-        error: {
-          message: 'The selected model is not available. Try a different model or check that the model ID is correct.',
-          type: 'model_not_found',
-          code: '404',
-        },
-      };
-    }
-
-    return { error: errorInfo };
+  // String or otherwise unstructured error field — classify generically.
+  if (data.error && typeof data.error !== 'object') {
+    const appError = classifySseError({ error_type: topLevelErrorType });
+    return toSafeError(appError, {
+      type: topLevelErrorType,
+      rawMessage: typeof data.error === 'string' ? data.error : JSON.stringify(data.error),
+    });
   }
 
-  // Handle string error
-  if (typeof data.error === 'string') {
-    return { error: { message: `Stream error: ${data.error}` } };
+  const errorObj = (data.error as Record<string, unknown> | undefined) ?? {};
+  const info = extractErrorInfo(errorObj);
+  const requestId = info.requestId ?? (typeof data.request_id === 'string' ? data.request_id : undefined);
+  const errorType = (info.errorType || topLevelErrorType || info.type || '').toLowerCase();
+
+  // New backend contract: known error_type values get dedicated copy.
+  if (KNOWN_SSE_ERROR_TYPES.has(errorType)) {
+    const appError = classifySseError({ error_type: errorType, request_id: requestId });
+    return toSafeError(appError, { type: errorType, code: info.code, requestId, rawMessage: info.rawMessage });
   }
 
-  // data.error exists but is neither object nor string - unusual case
-  return { error: { message: `Stream error: ${JSON.stringify(data.error)}` } };
+  // Legacy heuristics for older backend/provider chunks. The matched raw text
+  // is used for classification only — never rendered.
+  const lowerMessage = info.rawMessage.toLowerCase();
+  const errorCode = (info.code || '').toLowerCase();
+
+  if (
+    errorCode.includes('rate_limit') ||
+    errorType.includes('rate_limit') ||
+    lowerMessage.includes('rate limit') ||
+    lowerMessage.includes('too many requests') ||
+    errorObj.status === 429
+  ) {
+    const appError = classifySseError({ error_type: 'rate_limit_error', request_id: requestId });
+    return toSafeError(appError, { type: 'rate_limit', code: info.code || 'rate_limit_exceeded', requestId, rawMessage: info.rawMessage });
+  }
+
+  if (lowerMessage.includes('trial has expired') || lowerMessage.includes('insufficient credits')) {
+    return {
+      error: {
+        message: 'Trial credits have been used up. You can still use FREE models! Look for models with the "FREE" badge, or add credits to use premium models.',
+        type: 'credits_exhausted',
+        requestId,
+        rawDetail: info.rawMessage,
+      },
+    };
+  }
+
+  if (
+    lowerMessage === 'not found' ||
+    lowerMessage.includes('model not found') ||
+    lowerMessage.includes('no such model') ||
+    errorCode === '404' ||
+    errorObj.status === 404
+  ) {
+    const appError = classifySseError({ error_type: 'not_found_error', request_id: requestId });
+    return toSafeError(appError, { type: 'model_not_found', code: '404', requestId, rawMessage: info.rawMessage });
+  }
+
+  // Anything unmapped (including "upstream rejected" and unknown provider
+  // errors): treat as a provider-side stream failure with generic copy.
+  const appError = classifySseError({ error_type: lowerMessage.includes('upstream rejected') ? 'provider_error' : 'stream_error', request_id: requestId });
+  return toSafeError(appError, { type: info.type, code: info.code, requestId, rawMessage: info.rawMessage });
 }
 
 /**
@@ -402,6 +445,10 @@ export function parseSSEChunk(jsonStr: string): ParsedSSEData | null {
     throw new StreamingError(errorResult.error.message, {
       type: errorResult.error.type,
       code: errorResult.error.code,
+      retryable: errorResult.error.retryable,
+      requestId: errorResult.error.requestId,
+      rawDetail: errorResult.error.rawDetail,
+      appError: errorResult.error.appError,
     });
   }
 

--- a/src/lib/streaming/stream-chat.ts
+++ b/src/lib/streaming/stream-chat.ts
@@ -9,8 +9,9 @@
  * This file is kept for backwards compatibility during migration.
  */
 
-import * as Sentry from '@sentry/nextjs';
 import { StreamCoordinator } from '@/lib/stream-coordinator';
+import { classifyApiError, getUserMessage, ApiError, type AppError } from '@/lib/errors';
+import { trackBackendError } from '@/lib/backend-error-tracking';
 import type { StreamChunk, StreamConfig } from './types';
 import { parseSSEBuffer } from './sse-parser';
 import {
@@ -58,7 +59,123 @@ const CONFIG: Required<StreamConfig> = {
 };
 
 /**
+ * Read Retry-After from a response as seconds (supports numeric and HTTP-date forms).
+ */
+function readRetryAfterSeconds(response: Response): number | undefined {
+  const header = response.headers.get('retry-after');
+  if (!header) return undefined;
+
+  const numeric = Number(header);
+  if (!Number.isNaN(numeric) && numeric > 0) return numeric;
+
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) {
+    const seconds = (date - Date.now()) / 1000;
+    if (seconds > 0) return seconds;
+  }
+  return undefined;
+}
+
+/** Pull the backend's error code/type out of a (possibly proxy-wrapped) error body. */
+function readErrorCodeAndType(errorData: Record<string, unknown>): { code?: string; type?: string } {
+  const candidates = [errorData, errorData.errorData].filter(
+    (c): c is Record<string, unknown> => !!c && typeof c === 'object'
+  );
+  for (const candidate of candidates) {
+    const errorField = candidate.error;
+    if (errorField && typeof errorField === 'object') {
+      const obj = errorField as Record<string, unknown>;
+      return {
+        code: typeof obj.code === 'string' ? obj.code : undefined,
+        type: typeof obj.type === 'string' ? obj.type : undefined,
+      };
+    }
+    if (typeof candidate.code === 'string') {
+      return { code: candidate.code, type: typeof candidate.type === 'string' ? candidate.type : undefined };
+    }
+  }
+  return {};
+}
+
+/**
+ * Errors whose raw payload has already been sent to telemetry. Prevents
+ * double-reporting when nested retry generators re-throw the same error.
+ */
+const reportedErrors = new WeakSet<Error>();
+
+/** Mark an error as already reported to telemetry, then return it for throwing. */
+function markReported<T extends Error>(error: T): T {
+  reportedErrors.add(error);
+  return error;
+}
+
+/**
+ * Report a mid-stream (SSE) error to telemetry with its raw detail. No-op if
+ * this error object was already reported.
+ */
+function reportStreamError(error: StreamingError, url: string, requestBody: Record<string, unknown>): void {
+  if (reportedErrors.has(error)) return;
+  reportedErrors.add(error);
+  try {
+    trackBackendError(error, {
+      endpoint: url,
+      method: 'POST',
+      model: String(requestBody.model || 'unknown'),
+      gateway: typeof requestBody.gateway === 'string' ? requestBody.gateway : undefined,
+      requestId: error.requestId,
+      errorCode: error.code,
+      errorType: error.type,
+      rateLimitScope: error.rateLimitScope,
+      responseBody: error.rawDetail,
+    });
+  } catch {
+    // Telemetry must never break the stream.
+  }
+}
+
+/**
+ * Send the full raw failure payload to telemetry (Sentry). This is the ONLY
+ * place raw backend error text is allowed to go — never to the screen.
+ */
+function reportBackendFailure(
+  status: number,
+  errorData: unknown,
+  url: string,
+  requestBody: Record<string, unknown>,
+  extras: { requestId?: string; rateLimitScope?: string; retryCount?: number; errorCode?: string; errorType?: string }
+): void {
+  try {
+    let responseBody: string | undefined;
+    try {
+      responseBody = JSON.stringify(errorData);
+    } catch {
+      responseBody = String(errorData);
+    }
+    trackBackendError(new Error(`Chat API error: ${status} at ${url}`), {
+      endpoint: url,
+      statusCode: status,
+      method: 'POST',
+      model: String(requestBody.model || 'unknown'),
+      gateway: typeof requestBody.gateway === 'string' ? requestBody.gateway : undefined,
+      retryCount: extras.retryCount,
+      requestId: extras.requestId,
+      errorCode: extras.errorCode,
+      errorType: extras.errorType,
+      rateLimitScope: extras.rateLimitScope,
+      responseBody,
+    });
+  } catch {
+    // Telemetry must never break the stream.
+  }
+}
+
+/**
  * Handle HTTP error responses with appropriate error types.
+ *
+ * Every thrown error carries safe, user-facing copy in `.message` (mapped by
+ * status + backend error code via classifyApiError) plus the classified
+ * AppError so downstream display keeps request IDs / retry metadata. Raw
+ * backend text goes to telemetry only.
  */
 async function handleHttpError(
   response: Response,
@@ -71,80 +188,80 @@ async function handleHttpError(
 ): Promise<AsyncGenerator<StreamChunk> | null> {
   const errorData = await response.json().catch(() => ({}));
 
+  const retryAfterSeconds = readRetryAfterSeconds(response);
+  const rateLimitScopeHeader = response.headers.get('x-ratelimit-scope');
+  const headerRequestId = response.headers.get('x-request-id');
+  const { code: backendCode, type: backendType } = readErrorCodeAndType(errorData);
+
+  const appError = classifyApiError(response.status, errorData, {
+    retryAfter: retryAfterSeconds,
+    rateLimitScope: rateLimitScopeHeader,
+    requestId: headerRequestId,
+  });
+
   devError('API Error Response:', {
     status: response.status,
     errorData,
     url,
   });
 
+  // Raw payload → telemetry. Friendly copy → screen.
+  reportBackendFailure(response.status, errorData, url, requestBody, {
+    requestId: appError.requestId,
+    rateLimitScope: appError.rateLimitScope,
+    retryCount,
+    errorCode: backendCode,
+    errorType: backendType,
+  });
+
+  const throwWithAppError = (error: AppError): never => {
+    throw markReported(
+      new StreamingError(getUserMessage(error), {
+        code: error.code,
+        retryable: error.retryable,
+        requestId: error.requestId,
+        retryAfterSeconds: error.retryAfterSeconds,
+        rateLimitScope: error.rateLimitScope,
+        appError: error,
+      })
+    );
+  };
+
   // Handle specific status codes
   switch (response.status) {
     case 400: {
-      // Extract error message from various response formats:
-      // - Direct: errorData.detail, errorData.message
-      // - Nested error object: errorData.error?.message
-      // - Wrapped by API proxy: errorData.errorData?.detail, errorData.errorData?.message
-      const errorMessage =
+      // Internal-only raw text, used purely to classify legacy 400s that
+      // predate structured error codes. Never displayed.
+      const rawMessage = String(
         errorData.detail ||
-        errorData.error?.message ||
-        errorData.message ||
-        errorData.errorData?.detail ||
-        errorData.errorData?.message ||
-        errorData.errorData?.error?.message ||
-        'Bad request';
+          errorData.error?.message ||
+          errorData.message ||
+          errorData.errorData?.detail ||
+          errorData.errorData?.message ||
+          errorData.errorData?.error?.message ||
+          ''
+      ).toLowerCase();
 
-      devError('400 Bad Request details:', {
-        detail: errorData.detail,
-        message: errorData.message,
-        errorMessage: errorData.error?.message,
-        nestedDetail: errorData.errorData?.detail,
-        nestedMessage: errorData.errorData?.message,
-        fullErrorData: errorData,
-      });
-
-      if (
-        errorMessage.toLowerCase().includes('trial has expired') ||
-        errorMessage.toLowerCase().includes('insufficient credits')
-      ) {
-        throw new StreamingError(
-          'Trial credits have been used up. You can still use FREE models! Look for models with the "FREE" badge, or add credits to use premium models.'
+      if (rawMessage.includes('trial has expired') || rawMessage.includes('insufficient credits')) {
+        const creditsError = new ApiError(
+          'API_PAYMENT_REQUIRED',
+          'Trial credits have been used up. You can still use FREE models! Look for models with the "FREE" badge, or add credits to use premium models.',
+          { statusCode: 400, requestId: appError.requestId }
         );
+        return throwWithAppError(creditsError);
       }
 
-      if (errorMessage.toLowerCase().includes('upstream rejected')) {
-        throw new StreamingError(
-          `Backend error: ${errorMessage}. This may be a temporary issue. Please try again or select a different model.`
-        );
-      }
-
-      throw new StreamingError(`Bad request: ${errorMessage}`);
+      return throwWithAppError(appError);
     }
 
     case 401: {
       const errorCode = errorData.code;
 
-      // Capture auth error to Sentry
-      Sentry.captureException(
-        new Error(`Chat 401 Unauthorized: ${errorData.detail || errorData.message || 'Authentication required'}`),
-        {
-          tags: {
-            error_type: 'chat_auth_error',
-            http_status: 401,
-            error_code: errorCode || 'unknown',
-            model: String(requestBody.model || 'unknown'),
-          },
-          extra: {
-            errorData,
-            url,
-            retryCount,
-          },
-          level: 'warning',
-        }
-      );
-
       if (errorCode === 'GUEST_NOT_CONFIGURED') {
-        throw new AuthenticationError(
-          'Please sign in to use the chat feature. Create a free account to get started!'
+        throw markReported(
+          new AuthenticationError(
+            'Please sign in to use the chat feature. Create a free account to get started!'
+          )
         );
       }
 
@@ -172,61 +289,95 @@ async function handleHttpError(
         }
       }
 
-      throw new AuthenticationError(
-        'Your session has expired. Please sign in again to continue.'
+      throw markReported(
+        new AuthenticationError('Your session has expired. Please sign in again to continue.')
       );
     }
 
-    case 403:
+    case 402:
+      // Insufficient credits. classifyApiError produced API_PAYMENT_REQUIRED
+      // copy; the UI attaches an "Add credits" CTA to that code.
+      return throwWithAppError(appError);
+
+    case 403: {
       // 403 = the key is valid but lacks access/subscription for this action. This is NOT
       // an expired session; a re-login loop can never resolve a billing/access problem.
-      Sentry.captureException(
-        new Error('Chat 403 Forbidden - access/subscription denied'),
-        {
-          tags: {
-            error_type: 'chat_authorization_error',
-            http_status: 403,
-            model: String(requestBody.model || 'unknown'),
-          },
-          extra: {
-            errorData,
-            url,
-          },
-          level: 'warning',
-        }
+      if (appError.code === 'SUBSCRIPTION_INACTIVE') {
+        // subscription_* error codes — the UI attaches a "Renew" CTA.
+        return throwWithAppError(appError);
+      }
+      const accessError = new ApiError(
+        'API_ERROR',
+        "You don't have access to this model or action. If this is a paid model, add credits or upgrade your plan, then try again.",
+        { statusCode: 403, requestId: appError.requestId }
       );
-      throw new StreamingError(
-        "You don't have access to this model or action. If this is a paid model, add credits or upgrade your plan, then try again."
-      );
+      return throwWithAppError(accessError);
+    }
 
-    case 404:
-      throw new StreamingError(
-        `Model not found: ${errorData.detail || errorData.message || 'Unknown model'}`
+    case 404: {
+      const notFoundError = new ApiError(
+        'API_NOT_FOUND',
+        "That model isn't available. Please choose a different model.",
+        { statusCode: 404, requestId: appError.requestId }
       );
+      return throwWithAppError(notFoundError);
+    }
 
-    case 413:
-      throw new StreamingError(
-        'Image or request too large. Please try with a smaller image or reduce image quality.'
+    case 413: {
+      const tooLargeError = new ApiError(
+        'API_VALIDATION_ERROR',
+        'Image or request too large. Please try with a smaller image or reduce image quality.',
+        { statusCode: 413, requestId: appError.requestId }
       );
+      return throwWithAppError(tooLargeError);
+    }
 
     case 429: {
-      const detailMessage =
-        errorData.detail || errorData.message || errorData.error?.message || '';
+      const isUpstream = appError.rateLimitScope === 'upstream';
 
+      if (isUpstream) {
+        // The model provider is rate limited (common on free models) — this is
+        // NOT the user's fault. Auto-retry ONCE after Retry-After; the yielded
+        // status chunk lets the UI show a countdown while we wait.
+        if (retryCount === 0) {
+          const waitTime = Math.max(1000, Math.round((retryAfterSeconds ?? 3) * 1000)) + Math.floor(Math.random() * 500);
+          devLog(`Upstream rate limit, auto-retrying once in ${waitTime}ms...`);
+
+          return (async function* () {
+            yield {
+              status: 'rate_limit_retry' as const,
+              retryAfterMs: waitTime,
+              rateLimitScope: 'upstream' as const,
+            };
+            await sleep(waitTime);
+            yield* streamGenerator(url, apiKey, requestBody, Math.max(retryCount + 1, 1), maxRetries);
+          })();
+        }
+
+        throw markReported(
+          new RateLimitError(getUserMessage(appError), (retryAfterSeconds ?? 0) * 1000 || undefined, {
+            rateLimitScope: 'upstream',
+            requestId: appError.requestId,
+            appError,
+          })
+        );
+      }
+
+      // Gateway rate limit — the user is sending requests too quickly. Retry
+      // with backoff a few times, then surface the wait-N-seconds copy.
       if (retryCount < maxRetries) {
-        const retryAfterHeader = response.headers.get('retry-after');
-        const isConcurrencyLimit = detailMessage.toLowerCase().includes('concurrency');
-        const isBurstLimit = detailMessage.toLowerCase().includes('burst');
+        const rawDetail = String(
+          errorData.detail || errorData.message || errorData.error?.message || ''
+        ).toLowerCase();
+        const isConcurrencyLimit = rawDetail.includes('concurrency');
+        const isBurstLimit = rawDetail.includes('burst');
 
         const baseDelay = isConcurrencyLimit || isBurstLimit ? 3000 : 1500;
         const maxDelay = isConcurrencyLimit || isBurstLimit ? 30000 : 15000;
         let waitTime = Math.min(baseDelay * Math.pow(2, retryCount), maxDelay);
 
-        if (retryAfterHeader) {
-          const numericRetry = Number(retryAfterHeader);
-          if (!Number.isNaN(numericRetry) && numericRetry > 0) {
-            waitTime = Math.max(waitTime, numericRetry * 1000);
-          }
+        if (retryAfterSeconds) {
+          waitTime = Math.max(waitTime, retryAfterSeconds * 1000);
         }
 
         waitTime = Math.max(waitTime, 1500) + Math.floor(Math.random() * 500);
@@ -235,21 +386,24 @@ async function handleHttpError(
 
         // Return a generator that yields rate limit status then retries
         return (async function* () {
-          yield { status: 'rate_limit_retry' as const, retryAfterMs: waitTime };
+          yield {
+            status: 'rate_limit_retry' as const,
+            retryAfterMs: waitTime,
+            rateLimitScope: 'gateway' as const,
+          };
           await sleep(waitTime);
           yield* streamGenerator(url, apiKey, requestBody, retryCount + 1, maxRetries);
         })();
       }
 
-      throw new RateLimitError(
-        detailMessage || 'Rate limit exceeded. Please wait a moment and try again.'
+      throw markReported(
+        new RateLimitError(getUserMessage(appError), (retryAfterSeconds ?? 0) * 1000 || undefined, {
+          rateLimitScope: 'gateway',
+          requestId: appError.requestId,
+          appError,
+        })
       );
     }
-
-    case 500:
-      throw new StreamingError(
-        `Server error: ${errorData.detail || errorData.message || 'Internal server error'}. Please try again.`
-      );
 
     case 502:
     case 503:
@@ -266,17 +420,18 @@ async function handleHttpError(
         return streamGenerator(url, apiKey, requestBody, retryCount + 1, maxRetries);
       }
 
-      throw new StreamingError(
-        `Service unavailable. The backend appears to be temporarily unavailable. Please try again.`
+      const unavailableError = new ApiError(
+        'API_SERVER_ERROR',
+        'Service unavailable. The backend appears to be temporarily unavailable. Please try again.',
+        { statusCode: response.status, requestId: appError.requestId, retryable: true }
       );
+      return throwWithAppError(unavailableError);
     }
 
     default:
-      throw new StreamingError(
-        errorData.error?.message ||
-          errorData.detail ||
-          `Request failed with status ${response.status}`
-      );
+      // 500s and anything unmapped: generic copy from the classifier. The
+      // request ID rides along so the UI can show a subtle "Error ID".
+      return throwWithAppError(appError);
   }
 }
 
@@ -434,11 +589,16 @@ export async function* streamChatResponse(
 
         // Yield parsed chunks
         for (const chunk of chunks) {
-          // Handle error chunks from SSE parsing (e.g., finish_reason: 'error')
+          // Handle error chunks from SSE parsing (e.g., finish_reason: 'error').
+          // chunk.error.message is already safe copy from the parser.
           if (chunk.error) {
             throw new StreamingError(chunk.error.message, {
               type: chunk.error.type,
               code: chunk.error.code,
+              retryable: chunk.error.retryable ?? true,
+              requestId: chunk.error.requestId,
+              rawDetail: chunk.error.rawDetail,
+              appError: chunk.error.appError,
             });
           }
 
@@ -504,6 +664,11 @@ export async function* streamChatResponse(
       throw new StreamTimeoutError(
         'Request timed out. The model may be overloaded or generating a very long response.'
       );
+    }
+    // Mid-stream (SSE) errors weren't reported by handleHttpError — send their
+    // raw payload to telemetry here before rethrowing the friendly message.
+    if (error instanceof StreamingError) {
+      reportStreamError(error, url, requestBody);
     }
     throw error;
   }

--- a/src/lib/streaming/types.ts
+++ b/src/lib/streaming/types.ts
@@ -4,6 +4,8 @@
  * Type definitions for the streaming module.
  */
 
+import type { AppError, RateLimitScope } from '@/lib/errors';
+
 /**
  * Tool call from the model.
  */
@@ -43,6 +45,9 @@ export interface StreamChunk {
   /** Retry delay in ms when rate limited */
   retryAfterMs?: number;
 
+  /** Who enforced the rate limit (rate_limit_retry chunks): the model provider or our gateway */
+  rateLimitScope?: RateLimitScope;
+
   /** Performance timing metadata */
   timingMetadata?: {
     backendTimeMs?: number;
@@ -68,9 +73,17 @@ export interface ParsedSSEData {
   reasoning?: string;
   done?: boolean;
   error?: {
+    /** Safe, user-facing copy — never raw provider/backend text */
     message: string;
     type?: string;
     code?: string;
+    /** Backend request ID for support tracing */
+    requestId?: string;
+    retryable?: boolean;
+    /** Raw provider text — telemetry only, never render */
+    rawDetail?: string;
+    /** Classified AppError carrying the same copy plus metadata */
+    appError?: AppError;
   };
   // Tool calling events
   type?: 'tool_call' | 'tool_result';


### PR DESCRIPTION
Matches the frontend to the backend's new error contract (backend branch `claude/model-rate-limits-error-display-k7y4mf`) for `/v1/chat/completions` and the streaming SSE path. Users now see short, friendly, actionable messages; raw error details go to Sentry, never to the screen.

## What changed

### 1. No raw API error bodies rendered
- All errors are mapped by HTTP status + `error.code`/`error.type` to our own copy via `classifyApiError` (`src/lib/errors/index.ts`); anything unmapped gets "Something went wrong. Please try again."
- The live chat streaming path (`stream-chat.ts`, `sse-parser.ts`, `use-chat-stream.ts`, `ChatMessage.tsx`) previously leaked raw `detail`/provider text/JSON — all rewritten to carry safe copy plus structured metadata (`errorInfo`).
- Request IDs (from `X-Request-ID` or body `request_id`) surface subtly as "Error ID: …" under the error notice for support tracing, never inside the copy.
- Remaining leak sites fixed: models inline-chat, playground, cache settings.

### 2. Raw errors → telemetry
- Every non-2xx response and SSE error chunk reports the full payload (status, error code/type, detail, request ID, model, endpoint, rate-limit scope) to Sentry via an extended `trackBackendError`. A WeakSet prevents double-reporting through retry recursion.

### 3. Upstream vs gateway 429
- **Upstream** (`X-RateLimit-Scope: upstream`): "This model is busy right now — retrying shortly", a live countdown driven by `Retry-After`, and exactly one auto-retry. Never phrased as the user hitting their own limit.
- **Gateway**: "You're sending requests too quickly. Please wait N seconds" (long waits format as minutes/hours; guest daily limit keeps sign-up copy).
- Proxy routes forward `Retry-After`, `X-RateLimit-Scope`, `X-RateLimit-*`, `X-Request-ID` and the backend error body so the client can classify; upstream 429s are no longer silently retried server-side.

### 4. 402 Payment Required
- "You don't have enough credits for this request" with an **Add credits** CTA → `/settings/credits`. Backend detail string is not echoed.

### 5. 403 subscription_*
- `error.code` starting `subscription_` → "Your subscription is inactive" with a **Renew** CTA → `/settings?tab=billing`.

### 6. Streaming errors
- New `classifySseError` maps `rate_limit_error`, `capacity_error`, `provider_error`, `timeout_error`, `not_found_error`, `auth_error`, `stream_error` to friendly copy; provider/timeout use "The model had a problem responding. Your credits for this message were not charged — try again."
- Partial streamed content stays visible; the error renders as a non-blocking inline notice below it.

### 7. Retry UX
- **Try again** button for retryable failures (429/502/503/504, provider/timeout/stream errors) in the chat error display.

## Tests
- Status/code → user-copy mapping table, upstream-vs-gateway 429 branching, SSE `error_type` mapping, request-ID metadata, proxy-envelope unwrapping (`errors.test.ts`, `stream-chat.test.ts`, `sse-parser.test.ts`).
- 343 tests pass across affected suites; `pnpm typecheck` and lint clean.
- Pre-existing failures on master (`ai-sdk-completions` route suite tests a removed `streamText` implementation; a few ChatInput/FreeModelsBanner cases) are unchanged — verified identical before/after.

## Notes
- `/v1/images/generations` has no frontend call sites today, so nothing to update there.
- No request payloads or endpoints changed — only error handling, display copy, headers on error responses, and telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxeWCGxC4rCrpJma2oDYMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxeWCGxC4rCrpJma2oDYMJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer, safer error messages across chat, streaming, playground, and settings experiences.
  * Added structured error details, request IDs, retry actions, and live countdowns for rate-limit retries.
  * Improved handling of upstream and gateway rate limits, including automatic retry behavior.
  * Added friendly messaging for unavailable models, insufficient credits, and inactive subscriptions.
  * Forwarded relevant retry and rate-limit information for improved error handling.

* **Bug Fixes**
  * Prevented raw backend and provider error details from appearing in user-facing messages.
  * Improved backend error tracking and diagnostic context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->