### PR TITLE
fix(chat): select only live catalog models

### DIFF
--- a/src/components/chat-v2/ChatLayout.tsx
+++ b/src/components/chat-v2/ChatLayout.tsx
@@ -9,9 +9,14 @@ import { ChatSidebar } from "./ChatSidebar";
 import { MessageList } from "./MessageList";
 import { ChatInput } from "./ChatInput";
 import { ConnectionStatus } from "./ConnectionStatus";
-import { ModelSelect } from "@/components/chat-v2/model-select";
+import {
+  ModelSelect,
+  isCatalogModelSelectable,
+  mapCatalogModelToOption,
+} from "@/components/chat-v2/model-select";
 import { useChatUIStore } from "@/lib/store/chat-ui-store";
 import { useAuthSync } from "@/lib/hooks/use-auth-sync";
+import { useModels } from "@/lib/hooks/use-catalog";
 import { useAuthStore } from "@/lib/store/auth-store";
 import { usePrivy } from "@privy-io/react-auth";
 import { getApiKey } from "@/lib/api";
@@ -21,7 +26,6 @@ import { useNetworkStatus } from "@/hooks/use-network-status";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCreateSession } from "@/lib/hooks/use-chat-queries";
 import { useToast } from "@/hooks/use-toast";
-import { getImageGenerationModel } from "@/lib/hooks/use-auto-model-switch";
 import { SURPRISE_PROMPTS } from "@/lib/surprise-prompts";
 import {
   AlertDialog,
@@ -54,8 +58,8 @@ const ALL_PROMPTS = [
     { title: "What's the difference between HTTP and HTTPS?", subtitle: "Learn about web security basics" },
 ];
 
-// Quick action prompt chips
-// useImageModel: if true, switches to the default image generation model when clicked
+// Quick action prompt chips. The legacy useImageModel field only describes the
+// prompt intent; live catalog data remains the sole source for model selection.
 const PROMPT_CHIPS = [
     { label: "Create image", icon: ImageIcon, prompt: "Create an image of ", useImageModel: true },
     { label: "Analyze data", icon: BarChart3, prompt: "Analyze the following data: ", useImageModel: false },
@@ -150,6 +154,13 @@ export function ChatLayout() {
    const queryClient = useQueryClient();
    const createSession = useCreateSession();
    const { toast } = useToast();
+   const { data: catalogModels = [], isLoading: catalogModelsLoading } = useModels({ gateway: 'all' });
+   const selectableCatalogModels = useMemo(
+       () => catalogModels
+           .filter(isCatalogModelSelectable)
+           .map(mapCatalogModelToOption),
+       [catalogModels]
+   );
 
    // Track if user has clicked a prompt (to immediately hide welcome screen)
    const [pendingPrompt, setPendingPrompt] = useState<string | null>(null);
@@ -176,7 +187,7 @@ export function ChatLayout() {
        const messageParam = searchParams.get('message');
        const modelParam = searchParams.get('model');
 
-       if (messageParam && !urlMessageProcessedRef.current) {
+       if (messageParam && !urlMessageProcessedRef.current && !catalogModelsLoading) {
            urlMessageProcessedRef.current = true;
 
            // Always disable incognito mode when using chat prompts from homepage/start pages
@@ -189,28 +200,19 @@ export function ChatLayout() {
            // after this effect has already checked the stale isIncognitoMode value.
            setIncognitoMode(false);
 
-           // Set model from URL if provided
-           if (modelParam) {
-               // Create a minimal ModelOption from the URL parameter
-               const modelParts = modelParam.split('/');
-               const modelLabel = modelParts.length > 1 ? modelParts[modelParts.length - 1] : modelParam;
-               const gateway = modelParts.length > 1 ? modelParts[0] : undefined;
+           // A deep link may request a model, but it may only select an entry
+           // currently advertised by the live catalog. Otherwise retain a live
+           // current selection or fall back to the first live model.
+           const requestedModel = modelParam
+               ? selectableCatalogModels.find(model => model.value === modelParam)
+               : null;
+           const currentLiveModel = selectedModel
+               ? selectableCatalogModels.find(model => model.value === selectedModel.value)
+               : null;
+           const liveModel = requestedModel ?? currentLiveModel ?? selectableCatalogModels[0] ?? null;
 
-               // Format label: replace dashes/underscores with spaces and capitalize each word
-               const formattedLabel = modelLabel
-                   .replace(/[-_]/g, ' ')
-                   .split(' ')
-                   .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
-                   .join(' ');
-
-               setSelectedModel({
-                   value: modelParam,
-                   label: formattedLabel,
-                   category: 'General',
-                   sourceGateway: gateway,
-                   developer: gateway ? gateway.charAt(0).toUpperCase() + gateway.slice(1) : undefined,
-                   modalities: ['Text']
-               });
+           if (liveModel && liveModel.value !== selectedModel?.value) {
+               setSelectedModel(liveModel);
            }
 
            // Set the input value so it's visible in the textarea
@@ -228,6 +230,15 @@ export function ChatLayout() {
            // and open the login modal so they can sign up and then send manually.
            if (!isAuthenticated) {
                login();
+               return;
+           }
+
+           if (!liveModel) {
+               toast({
+                   title: "No model available",
+                   description: "The live catalog does not currently contain a routable model.",
+                   variant: "destructive",
+               });
                return;
            }
 
@@ -263,7 +274,18 @@ export function ChatLayout() {
                pendingTimeoutRef.current = null;
            }
        };
-   }, [searchParams, setInputValue, setSelectedModel, setIncognitoMode, isAuthenticated, login]);
+   }, [
+       searchParams,
+       catalogModelsLoading,
+       selectableCatalogModels,
+       selectedModel,
+       setInputValue,
+       setSelectedModel,
+       setIncognitoMode,
+       isAuthenticated,
+       login,
+       toast,
+   ]);
 
    // Clear pending prompt once we have real messages OR when session changes
    useEffect(() => {
@@ -332,15 +354,9 @@ export function ChatLayout() {
        });
    };
 
-   // Handle prompt chip selection - just sets input value without sending, allows user to complete the prompt
-   // If useImageModel is true, switches to the default image generation model
-   const handlePromptChipSelect = (prompt: string, useImageModel?: boolean) => {
-       // Switch to image generation model if requested
-       if (useImageModel) {
-           const imageModel = getImageGenerationModel();
-           setSelectedModel(imageModel);
-       }
-
+   // Prompt chips only fill the composer. Model selection stays catalog-driven;
+   // the legacy flag is retained in the chip shape without injecting a model.
+   const handlePromptChipSelect = (prompt: string, _useImageModel?: boolean) => {
        setInputValue(prompt);
        // Focus the input field so user can continue typing
        if (typeof window !== 'undefined' && (window as any).__chatInputFocus) {

--- a/src/components/chat-v2/__tests__/ChatLayout.test.tsx
+++ b/src/components/chat-v2/__tests__/ChatLayout.test.tsx
@@ -1,6 +1,17 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
+const mockSearchParamValues: Record<string, string | null> = {};
+const mockCatalogModels = [
+  {
+    id: 'grok-3',
+    name: 'Grok 3',
+    source_gateway: 'xai',
+    is_active: true,
+    health_status: 'healthy',
+  },
+];
+
 // Mock UI components
 jest.mock('@/components/ui/button', () => ({
   Button: ({ children, onClick, ...props }: any) => (
@@ -126,6 +137,10 @@ jest.mock('@/lib/hooks/use-auth-sync', () => ({
   })),
 }));
 
+jest.mock('@/lib/hooks/use-catalog', () => ({
+  useModels: () => ({ data: mockCatalogModels, isLoading: false }),
+}));
+
 const mockCreateSessionMutateAsync = jest.fn();
 jest.mock('@/lib/hooks/use-chat-queries', () => ({
   useSessionMessages: () => ({ data: [], isLoading: false }),
@@ -162,7 +177,7 @@ jest.mock('@tanstack/react-query', () => ({
 // Mock next/navigation for useSearchParams
 jest.mock('next/navigation', () => ({
   useSearchParams: () => ({
-    get: jest.fn(() => null),
+    get: jest.fn((key: string) => mockSearchParamValues[key] ?? null),
   }),
 }));
 
@@ -197,6 +212,14 @@ jest.mock('../MessageList', () => ({
 // Mock ModelSelect
 jest.mock('@/components/chat-v2/model-select', () => ({
   ModelSelect: () => <div data-testid="model-select">Model Select</div>,
+  isCatalogModelSelectable: (model: any) => Boolean(model.source_gateway),
+  mapCatalogModelToOption: (model: any) => ({
+    value: model.id,
+    label: model.name,
+    category: 'General',
+    sourceGateway: model.source_gateway,
+    modalities: ['Text'],
+  }),
 }));
 
 // Import after mocks
@@ -207,11 +230,13 @@ describe('ChatLayout', () => {
     jest.clearAllMocks();
     mockIsIncognitoMode = false;
     mockSetIncognitoMode.mockClear();
+    Object.keys(mockSearchParamValues).forEach(key => delete mockSearchParamValues[key]);
     delete (window as any).__chatInputSend;
     delete (window as any).__chatInputFocus;
   });
 
   afterEach(() => {
+    Object.keys(mockSearchParamValues).forEach(key => delete mockSearchParamValues[key]);
     delete (window as any).__chatInputSend;
     delete (window as any).__chatInputFocus;
   });
@@ -346,6 +371,27 @@ describe('ChatLayout', () => {
 
       rafSpy.mockRestore();
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('URL prompts', () => {
+    it('replaces an unavailable requested model with a live catalog model before sending', async () => {
+      mockSearchParamValues.message = 'Explain routing';
+      mockSearchParamValues.model = 'removed-provider/unavailable-model';
+      const mockSend = jest.fn();
+      (window as any).__chatInputSend = mockSend;
+
+      render(<ChatLayout />);
+
+      await waitFor(() => {
+        expect(mockSetSelectedModel).toHaveBeenCalledWith(
+          expect.objectContaining({ value: 'grok-3', sourceGateway: 'xai' })
+        );
+      });
+      expect(mockSetSelectedModel).not.toHaveBeenCalledWith(
+        expect.objectContaining({ value: 'removed-provider/unavailable-model' })
+      );
+      await waitFor(() => expect(mockSend).toHaveBeenCalled());
     });
   });
 });
@@ -1356,7 +1402,7 @@ describe('Prompt chips', () => {
     expect(mockFocus).toHaveBeenCalled();
   });
 
-  it('should switch to image generation model when "Create image" chip is clicked', () => {
+  it('should not inject a model when "Create image" chip is clicked', () => {
     (window as any).__chatInputFocus = jest.fn();
     render(<ChatLayout />);
 
@@ -1364,13 +1410,8 @@ describe('Prompt chips', () => {
     const createImageChip = screen.getByText('Create image');
     fireEvent.click(createImageChip);
 
-    // Should switch to image generation model (Gatewayz Router)
-    expect(mockSetSelectedModel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        value: 'openrouter/auto',
-        label: 'Gatewayz Router',
-      })
-    );
+    // The live catalog remains the only source of model selection.
+    expect(mockSetSelectedModel).not.toHaveBeenCalled();
 
     // Should also set the input value
     expect(mockSetInputValue).toHaveBeenCalledWith('Create an image of ');

--- a/src/components/chat-v2/__tests__/model-select.test.tsx
+++ b/src/components/chat-v2/__tests__/model-select.test.tsx
@@ -5,7 +5,7 @@ import {
   getGatewayAbbrev,
   getDeveloper,
   getModelSpeedTier,
-  ensureRouterOption,
+  isCatalogModelSelectable,
 } from '../model-select';
 
 // Mock isTauriDesktop for desktop mode tests
@@ -174,61 +174,34 @@ describe('getModelSpeedTier', () => {
   });
 });
 
-// Test ensureRouterOption helper function
-describe('ensureRouterOption', () => {
-  const ROUTER_VALUE = 'openrouter/auto';
+describe('isCatalogModelSelectable', () => {
+  const liveModel = {
+    id: 'openai/gpt-4o',
+    name: 'GPT-4o',
+    source_gateway: 'openai',
+    is_active: true,
+    is_routable: true,
+    health_status: 'healthy',
+  };
 
-  it('should add router option to empty array', () => {
-    const result = ensureRouterOption([]);
-    expect(result.length).toBe(1);
-    expect(result[0].value).toBe(ROUTER_VALUE);
-    expect(result[0].label).toBe('Gatewayz Router');
+  it('allows a live, routable catalog model', () => {
+    expect(isCatalogModelSelectable(liveModel)).toBe(true);
   });
 
-  it('should prepend router option when not present', () => {
-    const models: ModelOption[] = [
-      { value: 'openai/gpt-4', label: 'GPT-4', category: 'Paid' },
-      { value: 'anthropic/claude-3', label: 'Claude 3', category: 'Paid' },
-    ];
-    const result = ensureRouterOption(models);
-    expect(result.length).toBe(3);
-    expect(result[0].value).toBe(ROUTER_VALUE);
-    expect(result[1].value).toBe('openai/gpt-4');
+  it('rejects models without a routing source', () => {
+    expect(isCatalogModelSelectable({ ...liveModel, source_gateway: undefined })).toBe(false);
   });
 
-  it('should not duplicate router option when already present', () => {
-    const models: ModelOption[] = [
-      { value: ROUTER_VALUE, label: 'Existing Router', category: 'Router' },
-      { value: 'openai/gpt-4', label: 'GPT-4', category: 'Paid' },
-    ];
-    const result = ensureRouterOption(models);
-    expect(result.length).toBe(2);
-    // Router option should be merged with default properties
-    expect(result[0].value).toBe(ROUTER_VALUE);
+  it('rejects inactive models', () => {
+    expect(isCatalogModelSelectable({ ...liveModel, is_active: false })).toBe(false);
   });
 
-  it('should preserve original model properties', () => {
-    const models: ModelOption[] = [
-      {
-        value: 'openai/gpt-4',
-        label: 'GPT-4',
-        category: 'Paid',
-        developer: 'OpenAI',
-        speedTier: 'medium',
-      },
-    ];
-    const result = ensureRouterOption(models);
-    expect(result[1].developer).toBe('OpenAI');
-    expect(result[1].speedTier).toBe('medium');
+  it('rejects unroutable models', () => {
+    expect(isCatalogModelSelectable({ ...liveModel, is_routable: false })).toBe(false);
   });
 
-  it('should set router with correct default properties', () => {
-    const result = ensureRouterOption([]);
-    const router = result[0];
-    expect(router.category).toBe('Router');
-    expect(router.sourceGateway).toBe('openrouter');
-    expect(router.developer).toBe('Alpaca');
-    expect(router.modalities).toEqual(['Text', 'Image', 'File', 'Audio', 'Video']);
+  it('rejects models whose health is down', () => {
+    expect(isCatalogModelSelectable({ ...liveModel, health_status: 'DOWN' })).toBe(false);
   });
 });
 

--- a/src/components/chat-v2/model-select.tsx
+++ b/src/components/chat-v2/model-select.tsx
@@ -21,7 +21,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover"
-import { NEAR_INCOGNITO_MODELS } from "@/lib/store/chat-ui-store"
 import { useAuth } from "@/hooks/use-auth"
 import { useAuthStore } from "@/lib/store/auth-store"
 
@@ -50,25 +49,6 @@ interface ModelSelectProps {
 const FAVORITES_KEY = 'gatewayz_favorite_models';
 // Models are fetched via the shared `useModels` catalog hook (Task 8/react-query),
 // which handles caching (staleTime) — no manual localStorage cache needed here.
-
-const ROUTER_OPTION: ModelOption = {
-  value: 'openrouter/auto',
-  label: 'Gatewayz Router',
-  category: 'Router',
-  sourceGateway: 'openrouter',
-  developer: 'Alpaca',
-  modalities: ['Text', 'Image', 'File', 'Audio', 'Video'] // Router supports all modalities
-};
-
-export const ensureRouterOption = (options: ModelOption[]): ModelOption[] => {
-  const hasRouter = options.some((option) => option.value === ROUTER_OPTION.value);
-  if (hasRouter) {
-    return options.map((option) =>
-      option.value === ROUTER_OPTION.value ? { ...ROUTER_OPTION, ...option } : option
-    );
-  }
-  return [{ ...ROUTER_OPTION }, ...options];
-};
 
 // Clean model name by removing redundant suffixes like "(Free)" since we show icons
 export const cleanModelName = (name: string): string => {
@@ -239,6 +219,16 @@ export const mapCatalogModelToOption = (model: CatalogModel): ModelOption => {
   };
 };
 
+export const isCatalogModelSelectable = (model: CatalogModel): boolean => {
+  const sourceGateway = model.source_gateway || model.source_gateways?.[0];
+  const healthStatus = String(model.health_status || '').toLowerCase();
+
+  return Boolean(sourceGateway)
+    && model.is_active !== false
+    && model.is_routable !== false
+    && healthStatus !== 'down';
+};
+
 export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = false }: ModelSelectProps) {
   const { isAuthenticated } = useAuth()
   const { userData } = useAuthStore()
@@ -250,7 +240,6 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
   const [open, setOpen] = React.useState(false)
   const [favorites, setFavorites] = React.useState<Set<string>>(new Set())
   const [expandedDevelopers, setExpandedDevelopers] = React.useState<Set<string>>(new Set(['Favorites', 'Incognito']))
-  const [defaultModelSet, setDefaultModelSet] = React.useState(false)
   const [searchQuery, setSearchQuery] = React.useState('')
   const [debouncedSearchQuery, setDebouncedSearchQuery] = React.useState('')
   type SortMode = 'gateway' | 'az' | 'free-first' | 'speed'
@@ -265,7 +254,7 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
   const models = React.useMemo(() => {
     // Deduplicate models by ID - keep the first occurrence
     const uniqueModelsMap = new Map<string, CatalogModel>();
-    (rawModels ?? []).forEach((model) => {
+    (rawModels ?? []).filter(isCatalogModelSelectable).forEach((model) => {
       if (!uniqueModelsMap.has(model.id)) {
         uniqueModelsMap.set(model.id, model);
       }
@@ -274,8 +263,10 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
     // Filter to routable models only — a model without a sourceGateway
     // cannot be routed by the gateway layer, so it is not actually available.
     const availableOptions = modelOptions.filter(m => m.sourceGateway);
-    return ensureRouterOption(availableOptions);
-  }, [rawModels]);
+    return isIncognitoMode
+      ? availableOptions.filter(model => model.sourceGateway?.toLowerCase() === 'near')
+      : availableOptions;
+  }, [rawModels, isIncognitoMode]);
 
   const debouncedQueryTrim = debouncedSearchQuery.trim();
   // Server-side search when the user types — same gateway=all + search filter
@@ -287,8 +278,16 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
   );
   const searchLoading = !!debouncedQueryTrim && searchFetching;
   const searchResults = React.useMemo(
-    () => (debouncedQueryTrim ? (rawSearchResults ?? []).map(mapCatalogModelToOption) : []),
-    [rawSearchResults, debouncedQueryTrim]
+    () => {
+      if (!debouncedQueryTrim) return [];
+      const selectable = (rawSearchResults ?? [])
+        .filter(isCatalogModelSelectable)
+        .map(mapCatalogModelToOption);
+      return isIncognitoMode
+        ? selectable.filter(model => model.sourceGateway?.toLowerCase() === 'near')
+        : selectable;
+    },
+    [rawSearchResults, debouncedQueryTrim, isIncognitoMode]
   );
 
   // Debounce search query for performance
@@ -439,51 +438,18 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
     });
   }, [modelsByGateway]);
 
-  // Set a sensible default model once the catalog has loaded.
-  // Priority: claude-3.5-sonnet → gpt-4o → gemini-flash → first non-router priced model → first model.
-  // Only fires once and only when the current default is the hardcoded placeholder that
-  // doesn't exist in the catalog (cerebras/qwen-3-32b).
+  // Reconcile selection exclusively against the live catalog. This also clears
+  // persisted/deprecated selections and switches to a live NEAR model only when
+  // incognito mode has an advertised NEAR catalog entry.
   React.useEffect(() => {
-    if (defaultModelSet || models.length === 0) return;
-    // Only override if the currently selected model isn't in the fetched catalog
-    const isInCatalog = models.some(m => m.value === selectedModel?.value);
-    if (isInCatalog) {
-      setDefaultModelSet(true);
-      return;
-    }
+    if (modelsLoading) return;
+    if (selectedModel && models.some(model => model.value === selectedModel.value)) return;
 
-    // Ranked preference list of model IDs — ordered by quality/availability
-    const preferenceList = [
-      'anthropic/claude-sonnet-4.6',
-      'anthropic/claude-sonnet-4.5',
-      'anthropic/claude-sonnet-4',
-      'anthropic/claude-3.5-sonnet',
-      'anthropic/claude-3.7-sonnet',
-      'openai/gpt-4o',
-      'openai/gpt-4o-mini',
-      'google/gemini-2.0-flash-001',
-      'google/gemini-flash-1.5',
-      'anthropic/claude-3.5-haiku',
-      'anthropic/claude-3-haiku',
-    ];
-
-    // Try preference list first
-    for (const id of preferenceList) {
-      const found = models.find(m => m.value === id);
-      if (found) {
-        onSelectModel(found);
-        setDefaultModelSet(true);
-        return;
-      }
+    const nextModel = models[0] ?? null;
+    if ((selectedModel?.value ?? null) !== (nextModel?.value ?? null)) {
+      onSelectModel(nextModel);
     }
-
-    // Fallback: first non-router model with a sourceGateway (skip ROUTER_OPTION)
-    const first = models.find(m => m.value !== 'openrouter/auto' && m.sourceGateway);
-    if (first) {
-      onSelectModel(first);
-    }
-    setDefaultModelSet(true);
-  }, [models, selectedModel, defaultModelSet, onSelectModel]);
+  }, [models, selectedModel, modelsLoading, onSelectModel]);
 
   // Get favorite models
   const favoriteModels = React.useMemo(() => {
@@ -530,7 +496,7 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
       return {
         modelsByGateway,
         favoriteModels,
-        incognitoModels: NEAR_INCOGNITO_MODELS,
+        incognitoModels: isIncognitoMode ? models : [],
       };
     }
 
@@ -579,14 +545,16 @@ export function ModelSelect({ selectedModel, onSelectModel, isIncognitoMode = fa
     const filteredFavorites = modelsToFilter.filter(model =>
       favorites.has(model.value) && matchesQuery(model)
     );
-    const filteredIncognito = NEAR_INCOGNITO_MODELS.filter(model => matchesQuery(model));
+    const filteredIncognito = isIncognitoMode
+      ? modelsToFilter.filter(model => matchesQuery(model))
+      : [];
 
     return {
       modelsByGateway: filteredByGateway,
       favoriteModels: filteredFavorites,
       incognitoModels: filteredIncognito,
     };
-  }, [debouncedSearchQuery, modelsByGateway, favoriteModels, mergedModelsForSearch, favorites]);
+  }, [debouncedSearchQuery, modelsByGateway, favoriteModels, mergedModelsForSearch, favorites, isIncognitoMode, models]);
 
   // Destructure for cleaner access in render
   const filteredModelsByGateway = filteredData.modelsByGateway;

--- a/src/lib/__tests__/models-service.search.node.test.ts
+++ b/src/lib/__tests__/models-service.search.node.test.ts
@@ -48,4 +48,20 @@ describe('models-service search (server-side)', () => {
     expect(requestedUrls.some((url) => /\/v1\/models\?gateway=openrouter/.test(url))).toBe(true);
     expect(requestedUrls.some((url) => url.includes('/v1/models/search'))).toBe(false);
   });
+
+  it('caps catalog page requests at the backend search limit', async () => {
+    await getModelsForGateway('openrouter', 1000);
+
+    const requestedUrls = mockFetch.mock.calls.map((call) => String(call[0]));
+    expect(requestedUrls.some((url) => url.includes('limit=100'))).toBe(true);
+    expect(requestedUrls.every((url) => !url.includes('limit=1000'))).toBe(true);
+  });
+
+  it('uses the same bounded page size for search requests', async () => {
+    await getModelsForGateway('all', 1000, 'claude');
+
+    const requestedUrls = mockFetch.mock.calls.map((call) => String(call[0]));
+    expect(requestedUrls.some((url) => url.includes('/v1/models/search') && url.includes('limit=100'))).toBe(true);
+    expect(requestedUrls.every((url) => !url.includes('limit=1000'))).toBe(true);
+  });
 });

--- a/src/lib/catalog-api.ts
+++ b/src/lib/catalog-api.ts
@@ -45,6 +45,9 @@ export interface CatalogModel {
   source_gateway?: string;
   source_gateways?: string[];
   is_private?: boolean;
+  is_active?: boolean;
+  is_routable?: boolean;
+  health_status?: string;
   // Passthrough for any additional fields the backend adds.
   [key: string]: unknown;
 }

--- a/src/lib/hooks/__tests__/use-auto-model-switch.test.ts
+++ b/src/lib/hooks/__tests__/use-auto-model-switch.test.ts
@@ -1,7 +1,31 @@
 import { renderHook, act } from '@testing-library/react';
-import { useAutoModelSwitch, modelSupportsModality, getMultimodalModel, getImageGenerationModel, DEFAULT_IMAGE_GENERATION_MODEL } from '../use-auto-model-switch';
+import { useAutoModelSwitch, modelSupportsModality, getMultimodalModel } from '../use-auto-model-switch';
 import { ModelOption } from '@/components/chat-v2/model-select';
 import * as Sentry from '@sentry/nextjs';
+
+const LIVE_CATALOG_MODELS = [
+  {
+    id: 'test-provider/live-multimodal',
+    name: 'Live Multimodal',
+    source_gateway: 'test-provider',
+    architecture: {
+      input_modalities: ['text', 'image', 'video', 'audio', 'file'],
+    },
+    is_active: true,
+    is_routable: true,
+    health_status: 'healthy',
+  },
+];
+
+const LIVE_MODEL_OPTIONS: ModelOption[] = [
+  {
+    value: 'test-provider/live-multimodal',
+    label: 'Live Multimodal',
+    category: 'General',
+    sourceGateway: 'test-provider',
+    modalities: ['Text', 'Image', 'Video', 'Audio', 'File'],
+  },
+];
 
 // Mock Sentry
 jest.mock('@sentry/nextjs', () => ({
@@ -23,6 +47,11 @@ jest.mock('@/lib/store/chat-ui-store', () => ({
     };
     return selector(state);
   },
+}));
+
+const mockUseModels = jest.fn(() => ({ data: LIVE_CATALOG_MODELS }));
+jest.mock('@/lib/hooks/use-catalog', () => ({
+  useModels: () => mockUseModels(),
 }));
 
 describe('modelSupportsModality', () => {
@@ -72,60 +101,48 @@ describe('modelSupportsModality', () => {
 
 describe('getMultimodalModel', () => {
   it('should return a model that supports images', () => {
-    const model = getMultimodalModel('image');
-    expect(model).toBeDefined();
-    expect(modelSupportsModality(model.modalities, 'image')).toBe(true);
+    const model = getMultimodalModel(LIVE_MODEL_OPTIONS, 'image');
+    expect(model).not.toBeNull();
+    expect(modelSupportsModality(model?.modalities, 'image')).toBe(true);
   });
 
   it('should return a model that supports video', () => {
-    const model = getMultimodalModel('video');
-    expect(model).toBeDefined();
-    expect(modelSupportsModality(model.modalities, 'video')).toBe(true);
+    const model = getMultimodalModel(LIVE_MODEL_OPTIONS, 'video');
+    expect(model).not.toBeNull();
+    expect(modelSupportsModality(model?.modalities, 'video')).toBe(true);
   });
 
   it('should return a model that supports audio', () => {
-    const model = getMultimodalModel('audio');
-    expect(model).toBeDefined();
-    expect(modelSupportsModality(model.modalities, 'audio')).toBe(true);
+    const model = getMultimodalModel(LIVE_MODEL_OPTIONS, 'audio');
+    expect(model).not.toBeNull();
+    expect(modelSupportsModality(model?.modalities, 'audio')).toBe(true);
   });
 
   it('should return a model that supports files', () => {
-    const model = getMultimodalModel('file');
-    expect(model).toBeDefined();
-    expect(modelSupportsModality(model.modalities, 'file')).toBe(true);
+    const model = getMultimodalModel(LIVE_MODEL_OPTIONS, 'file');
+    expect(model).not.toBeNull();
+    expect(modelSupportsModality(model?.modalities, 'file')).toBe(true);
   });
 
-  it('should return Gatewayz Router as default (supports all modalities)', () => {
-    const model = getMultimodalModel('image');
-    expect(model.value).toBe('openrouter/auto');
-    expect(model.label).toBe('Gatewayz Router');
+  it('should select from the supplied live catalog options', () => {
+    const model = getMultimodalModel(LIVE_MODEL_OPTIONS, 'image');
+    expect(model?.value).toBe('test-provider/live-multimodal');
+    expect(model?.label).toBe('Live Multimodal');
   });
 
-  it('should log warning when no model found and return fallback', () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-    // Force a scenario where find returns undefined
-    const originalFind = Array.prototype.find;
-    Array.prototype.find = jest.fn().mockReturnValue(undefined);
-
-    const model = getMultimodalModel('image');
-    expect(model).toBe(DEFAULT_IMAGE_GENERATION_MODEL);
-    expect(consoleWarnSpy).toHaveBeenCalled();
-
-    // Restore
-    Array.prototype.find = originalFind;
-    consoleWarnSpy.mockRestore();
+  it('should return null instead of inventing a fallback model', () => {
+    expect(getMultimodalModel([], 'image')).toBeNull();
   });
 
-  it('should capture Sentry exception on error and return fallback', () => {
+  it('should capture Sentry exception on error and return null', () => {
     // Force an error
     const originalFind = Array.prototype.find;
     Array.prototype.find = jest.fn().mockImplementation(() => {
       throw new Error('Find error');
     });
 
-    const model = getMultimodalModel('image');
-    expect(model).toBe(DEFAULT_IMAGE_GENERATION_MODEL);
+    const model = getMultimodalModel(LIVE_MODEL_OPTIONS, 'image');
+    expect(model).toBeNull();
     expect(Sentry.captureException).toHaveBeenCalled();
 
     // Restore
@@ -133,57 +150,10 @@ describe('getMultimodalModel', () => {
   });
 });
 
-describe('getImageGenerationModel', () => {
-  it('should return the default image generation model', () => {
-    const model = getImageGenerationModel();
-    expect(model).toBeDefined();
-    expect(model.value).toBe('openrouter/auto');
-    expect(model.label).toBe('Gatewayz Router');
-  });
-
-  it('should return a model that supports image generation', () => {
-    const model = getImageGenerationModel();
-    // Image generation models should support the Image modality for routing
-    expect(modelSupportsModality(model.modalities, 'image')).toBe(true);
-  });
-
-  it('should return the same model as DEFAULT_IMAGE_GENERATION_MODEL', () => {
-    const model = getImageGenerationModel();
-    expect(model).toEqual(DEFAULT_IMAGE_GENERATION_MODEL);
-  });
-
-  it('should have all required ModelOption fields', () => {
-    const model = getImageGenerationModel();
-    expect(model.value).toBeDefined();
-    expect(model.label).toBeDefined();
-    expect(model.category).toBeDefined();
-    expect(model.sourceGateway).toBeDefined();
-    expect(model.developer).toBeDefined();
-    expect(model.modalities).toBeDefined();
-    expect(Array.isArray(model.modalities)).toBe(true);
-  });
-});
-
-describe('DEFAULT_IMAGE_GENERATION_MODEL', () => {
-  it('should be the Gatewayz Router', () => {
-    expect(DEFAULT_IMAGE_GENERATION_MODEL.value).toBe('openrouter/auto');
-    expect(DEFAULT_IMAGE_GENERATION_MODEL.label).toBe('Gatewayz Router');
-    expect(DEFAULT_IMAGE_GENERATION_MODEL.category).toBe('Router');
-  });
-
-  it('should support all major modalities', () => {
-    const modalities = DEFAULT_IMAGE_GENERATION_MODEL.modalities;
-    expect(modalities).toContain('Text');
-    expect(modalities).toContain('Image');
-    expect(modalities).toContain('File');
-    expect(modalities).toContain('Audio');
-    expect(modalities).toContain('Video');
-  });
-});
-
 describe('useAutoModelSwitch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseModels.mockReturnValue({ data: LIVE_CATALOG_MODELS });
   });
 
   describe('checkAndSwitchModel', () => {
@@ -546,6 +516,7 @@ describe('useAutoModelSwitch', () => {
 describe('integration with common model scenarios', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseModels.mockReturnValue({ data: LIVE_CATALOG_MODELS });
   });
 
   it('should switch from Qwen3 32B (text-only) when image is uploaded', () => {
@@ -568,7 +539,7 @@ describe('integration with common model scenarios', () => {
 
     expect(mockSetSelectedModel).toHaveBeenCalledWith(
       expect.objectContaining({
-        value: 'openrouter/auto',
+        value: 'test-provider/live-multimodal',
       })
     );
     expect(mockToast).toHaveBeenCalledWith(

--- a/src/lib/hooks/use-auto-model-switch.ts
+++ b/src/lib/hooks/use-auto-model-switch.ts
@@ -1,62 +1,13 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import * as Sentry from '@sentry/nextjs';
-import { ModelOption } from '@/components/chat-v2/model-select';
+import {
+  type ModelOption,
+  isCatalogModelSelectable,
+  mapCatalogModelToOption,
+} from '@/components/chat-v2/model-select';
 import { useChatUIStore } from '@/lib/store/chat-ui-store';
 import { useToast } from '@/hooks/use-toast';
-
-// Default model for image generation tasks
-// The Gatewayz Router supports image generation via tools and routes to the best provider
-export const DEFAULT_IMAGE_GENERATION_MODEL: ModelOption = {
-  value: 'openrouter/auto',
-  label: 'Gatewayz Router',
-  category: 'Router',
-  sourceGateway: 'openrouter',
-  developer: 'Alpaca',
-  modalities: ['Text', 'Image', 'File', 'Audio', 'Video']
-};
-
-// Get the default model for image generation
-export const getImageGenerationModel = (): ModelOption => {
-  return DEFAULT_IMAGE_GENERATION_MODEL;
-};
-
-// List of known multimodal models that support image input
-// These are prioritized in order of preference
-const MULTIMODAL_MODELS: ModelOption[] = [
-  DEFAULT_IMAGE_GENERATION_MODEL,
-  {
-    value: 'google/gemini-2.0-flash-001',
-    label: 'Gemini 2.0 Flash',
-    category: 'Multimodal',
-    sourceGateway: 'openrouter',
-    developer: 'Google',
-    modalities: ['Text', 'Image']
-  },
-  {
-    value: 'anthropic/claude-3.5-sonnet',
-    label: 'Claude 3.5 Sonnet',
-    category: 'Multimodal',
-    sourceGateway: 'openrouter',
-    developer: 'Anthropic',
-    modalities: ['Text', 'Image']
-  },
-  {
-    value: 'openai/gpt-4o',
-    label: 'GPT-4o',
-    category: 'Multimodal',
-    sourceGateway: 'openrouter',
-    developer: 'OpenAI',
-    modalities: ['Text', 'Image']
-  },
-  {
-    value: 'openai/gpt-4o-mini',
-    label: 'GPT-4o mini',
-    category: 'Multimodal',
-    sourceGateway: 'openrouter',
-    developer: 'OpenAI',
-    modalities: ['Text', 'Image']
-  },
-];
+import { useModels } from '@/lib/hooks/use-catalog';
 
 // Helper to check if a model supports a specific modality
 export const modelSupportsModality = (
@@ -88,24 +39,18 @@ export const modelSupportsModality = (
   }
 };
 
-// Get the best multimodal model for a given media type
-export const getMultimodalModel = (mediaType: 'image' | 'video' | 'audio' | 'file'): ModelOption => {
+export type MediaType = 'image' | 'video' | 'audio' | 'file';
+
+// Choose only from models that the live backend catalog currently advertises.
+export const getMultimodalModel = (
+  models: ModelOption[],
+  mediaType: MediaType
+): ModelOption | null => {
   try {
-    // For now, return the first model that supports the media type
-    // The Gatewayz Router is the default as it supports all modalities
-    const model = MULTIMODAL_MODELS.find(m =>
+    return models.find(m =>
       modelSupportsModality(m.modalities, mediaType)
-    );
-
-    if (!model) {
-      // Fallback to router if no suitable model found
-      console.warn(`[getMultimodalModel] No model found for ${mediaType}, using Gatewayz Router`);
-      return MULTIMODAL_MODELS[0];
-    }
-
-    return model;
+    ) ?? null;
   } catch (error) {
-    // Fallback: return Gatewayz Router on any error
     Sentry.captureException(error, {
       tags: {
         function: 'getMultimodalModel',
@@ -118,15 +63,20 @@ export const getMultimodalModel = (mediaType: 'image' | 'video' | 'audio' | 'fil
       },
       level: 'error',
     });
-    return MULTIMODAL_MODELS[0];
+    return null;
   }
 };
-
-export type MediaType = 'image' | 'video' | 'audio' | 'file';
 
 export function useAutoModelSwitch() {
   const { toast } = useToast();
   const setSelectedModel = useChatUIStore(state => state.setSelectedModel);
+  const { data: catalogModels } = useModels({ gateway: 'all' });
+  const availableModels = useMemo(
+    () => (catalogModels ?? [])
+      .filter(isCatalogModelSelectable)
+      .map(mapCatalogModelToOption),
+    [catalogModels]
+  );
 
   /**
    * Check if the current model supports the given media type.
@@ -143,7 +93,15 @@ export function useAutoModelSwitch() {
     try {
       // If no model is selected, select a multimodal one
       if (!currentModel) {
-        const newModel = getMultimodalModel(mediaType);
+        const newModel = getMultimodalModel(availableModels, mediaType);
+        if (!newModel) {
+          toast({
+            title: 'No compatible model available',
+            description: `No live model currently advertises ${mediaType} input support.`,
+            variant: 'destructive',
+          });
+          return false;
+        }
         setSelectedModel(newModel);
         toast({
           title: 'Model switched',
@@ -156,8 +114,16 @@ export function useAutoModelSwitch() {
       const supportsMedia = modelSupportsModality(currentModel.modalities, mediaType);
 
       if (!supportsMedia) {
-        // Find a model that supports this media type
-        const newModel = getMultimodalModel(mediaType);
+        // Find a live catalog model that supports this media type.
+        const newModel = getMultimodalModel(availableModels, mediaType);
+        if (!newModel) {
+          toast({
+            title: 'No compatible model available',
+            description: `No live model currently advertises ${mediaType} input support.`,
+            variant: 'destructive',
+          });
+          return false;
+        }
 
         // Validate the new model has required fields
         if (!newModel.value || !newModel.label) {
@@ -197,7 +163,7 @@ export function useAutoModelSwitch() {
 
       return false;
     }
-  }, [setSelectedModel, toast]);
+  }, [availableModels, setSelectedModel, toast]);
 
   /**
    * Check if the current model supports image input

--- a/src/lib/models-service.ts
+++ b/src/lib/models-service.ts
@@ -10,6 +10,7 @@ import {
 import { trackBadBackendResponse, trackBackendNetworkError, trackBackendProcessingError } from '@/lib/backend-error-tracking';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'https://api.gatewayz.ai';
+const MODEL_PAGE_SIZE = 100;
 
 // TypeScript interface for paginated API response
 interface PaginatedResponse {
@@ -191,9 +192,10 @@ function getApiBaseUrl(): string {
 // Helper function to fetch models from a specific gateway
 async function fetchModelsFromGateway(gateway: string, limit?: number, search?: string): Promise<any[]> {
   const allModels: any[] = [];
-  // Backend enforces max limit of 1000 per page (returns 422 for higher values)
-  // Use 1000 as default page size for optimal throughput with pagination
-  const requestLimit = limit ? Math.min(limit, 1000) : 1000;
+  // Keep catalog and search requests on the same bounded page contract. Search
+  // rejects values above 100, and using a stable page size prevents callers from
+  // selecting a stale parameter-specific response-cache variant.
+  const requestLimit = Math.min(limit ?? MODEL_PAGE_SIZE, MODEL_PAGE_SIZE);
   // Use centralized PRIORITY_GATEWAYS for fast gateway detection
   // Timeouts: 180s for 'all' (aggregated endpoint needs time to fetch from all gateways),
   // 5s for fast gateways, 30s for slow (HuggingFace)

--- a/src/lib/store/__tests__/chat-ui-store.test.ts
+++ b/src/lib/store/__tests__/chat-ui-store.test.ts
@@ -1,4 +1,4 @@
-import { useChatUIStore, INCOGNITO_DEFAULT_MODEL, NEAR_INCOGNITO_MODELS } from '../chat-ui-store';
+import { useChatUIStore } from '../chat-ui-store';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -77,53 +77,6 @@ describe('chat-ui-store', () => {
     });
   });
 
-  describe('INCOGNITO_DEFAULT_MODEL', () => {
-    it('should export the incognito default model constant', () => {
-      expect(INCOGNITO_DEFAULT_MODEL).toBeDefined();
-      expect(INCOGNITO_DEFAULT_MODEL.value).toBe('near/zai-org/GLM-4.6');
-      expect(INCOGNITO_DEFAULT_MODEL.label).toBe('GLM-4.6');
-      expect(INCOGNITO_DEFAULT_MODEL.sourceGateway).toBe('near');
-    });
-  });
-
-  describe('NEAR_INCOGNITO_MODELS', () => {
-    it('should export all NEAR incognito models', () => {
-      expect(NEAR_INCOGNITO_MODELS).toBeDefined();
-      expect(Array.isArray(NEAR_INCOGNITO_MODELS)).toBe(true);
-      expect(NEAR_INCOGNITO_MODELS.length).toBe(4);
-    });
-
-    it('should include all 4 tested NEAR AI models', () => {
-      const modelIds = NEAR_INCOGNITO_MODELS.map(m => m.value);
-
-      expect(modelIds).toContain('near/zai-org/GLM-4.6');
-      expect(modelIds).toContain('near/deepseek-ai/DeepSeek-V3.1');
-      expect(modelIds).toContain('near/openai/gpt-oss-120b');
-      expect(modelIds).toContain('near/Qwen/Qwen3-30B-A3B-Instruct-2507');
-    });
-
-    it('should have all models with near gateway', () => {
-      NEAR_INCOGNITO_MODELS.forEach(model => {
-        expect(model.sourceGateway).toBe('near');
-      });
-    });
-
-    it('should have INCOGNITO_DEFAULT_MODEL as the first model', () => {
-      expect(NEAR_INCOGNITO_MODELS[0]).toEqual(INCOGNITO_DEFAULT_MODEL);
-    });
-
-    it('should have valid model structure for all models', () => {
-      NEAR_INCOGNITO_MODELS.forEach(model => {
-        expect(model.value).toBeDefined();
-        expect(model.label).toBeDefined();
-        expect(model.category).toBeDefined();
-        expect(model.sourceGateway).toBe('near');
-        expect(model.developer).toBeDefined();
-        expect(model.modalities).toContain('Text');
-      });
-    });
-  });
-
   describe('isIncognitoMode', () => {
     it('should have initial incognito mode set to false', () => {
       const state = useChatUIStore.getState();
@@ -167,14 +120,13 @@ describe('chat-ui-store', () => {
       expect(localStorageMock.setItem).toHaveBeenLastCalledWith('gatewayz_incognito_mode', 'false');
     });
 
-    it('should switch to GLM-4.6 model when incognito mode is enabled', () => {
+    it('should clear the model until the live NEAR catalog loads', () => {
       const { setIncognitoMode } = useChatUIStore.getState();
 
       setIncognitoMode(true);
 
       const state = useChatUIStore.getState();
-      expect(state.selectedModel?.value).toBe('near/zai-org/GLM-4.6');
-      expect(state.selectedModel?.label).toBe('GLM-4.6');
+      expect(state.selectedModel).toBeNull();
     });
 
     it('should restore previous model when incognito mode is disabled', () => {
@@ -190,9 +142,9 @@ describe('chat-ui-store', () => {
 
       const { setIncognitoMode } = useChatUIStore.getState();
 
-      // Enable incognito - should switch to GLM-4.6 and save previous model
+      // Enable incognito - the catalog owns selection and the previous model is saved
       setIncognitoMode(true);
-      expect(useChatUIStore.getState().selectedModel?.value).toBe('near/zai-org/GLM-4.6');
+      expect(useChatUIStore.getState().selectedModel).toBeNull();
       expect(useChatUIStore.getState().previousModel?.value).toBe('openai/gpt-4');
 
       // Disable incognito - should restore previous model (GPT-4)
@@ -220,14 +172,14 @@ describe('chat-ui-store', () => {
       );
     });
 
-    it('should switch model via toggleIncognitoMode', () => {
+    it('should clear the model via toggleIncognitoMode until the catalog resolves it', () => {
       const { toggleIncognitoMode } = useChatUIStore.getState();
 
       toggleIncognitoMode();
 
       const state = useChatUIStore.getState();
       expect(state.isIncognitoMode).toBe(true);
-      expect(state.selectedModel?.value).toBe('near/zai-org/GLM-4.6');
+      expect(state.selectedModel).toBeNull();
     });
 
     it('should be idempotent - calling setIncognitoMode(false) when already off should not change model', () => {
@@ -362,29 +314,35 @@ describe('chat-ui-store', () => {
       // Verify state was fixed
       const state = useChatUIStore.getState();
       expect(state.isIncognitoMode).toBe(true);
-      expect(state.selectedModel?.value).toBe('near/zai-org/GLM-4.6');
-      expect(state.selectedModel?.sourceGateway).toBe('near');
+      expect(state.selectedModel).toBeNull();
       expect(state.previousModel?.value).toBe('openrouter/deepseek/deepseek-r1');
       expect(state._hasHydrated).toBe(true);
     });
 
-    it('should not change state if already using a NEAR model', () => {
+    it('should clear a persisted NEAR model so the current catalog revalidates it', () => {
       localStorageMock.setItem('gatewayz_incognito_mode', 'true');
 
-      // State is already correct
+      const persistedNearModel = {
+        value: 'near/deepseek-ai/DeepSeek-V3.1',
+        label: 'DeepSeek V3.1',
+        category: 'General',
+        sourceGateway: 'near',
+        developer: 'DeepSeek',
+        modalities: ['Text']
+      };
       useChatUIStore.setState({
         isIncognitoMode: true,
-        selectedModel: INCOGNITO_DEFAULT_MODEL,
+        selectedModel: persistedNearModel,
         previousModel: null,
         _hasHydrated: false
       });
 
       useChatUIStore.getState().syncIncognitoState();
 
-      // State should remain unchanged (except _hasHydrated)
       const state = useChatUIStore.getState();
       expect(state.isIncognitoMode).toBe(true);
-      expect(state.selectedModel?.value).toBe('near/zai-org/GLM-4.6');
+      expect(state.selectedModel).toBeNull();
+      expect(state.previousModel).toEqual(persistedNearModel);
       expect(state._hasHydrated).toBe(true);
     });
 
@@ -482,7 +440,7 @@ describe('chat-ui-store', () => {
       // Should restore the stored GPT-4 as previousModel, not the SSR default DeepSeek R1
       const state = useChatUIStore.getState();
       expect(state.isIncognitoMode).toBe(true);
-      expect(state.selectedModel?.value).toBe('near/zai-org/GLM-4.6');
+      expect(state.selectedModel).toBeNull();
       expect(state.previousModel?.value).toBe('openai/gpt-4');
       expect(state._hasHydrated).toBe(true);
     });

--- a/src/lib/store/chat-ui-store.ts
+++ b/src/lib/store/chat-ui-store.ts
@@ -1,46 +1,6 @@
 import { create } from 'zustand';
 import { ModelOption } from '@/components/chat-v2/model-select';
 
-// All NEAR AI models available for Incognito mode
-// These models support privacy-focused conversations via NEAR AI
-export const NEAR_INCOGNITO_MODELS: ModelOption[] = [
-  {
-    value: 'near/zai-org/GLM-4.6',
-    label: 'GLM-4.6',
-    category: 'General',
-    sourceGateway: 'near',
-    developer: 'ZAI',
-    modalities: ['Text']
-  },
-  {
-    value: 'near/deepseek-ai/DeepSeek-V3.1',
-    label: 'DeepSeek V3.1',
-    category: 'General',
-    sourceGateway: 'near',
-    developer: 'DeepSeek',
-    modalities: ['Text']
-  },
-  {
-    value: 'near/openai/gpt-oss-120b',
-    label: 'GPT OSS 120B',
-    category: 'General',
-    sourceGateway: 'near',
-    developer: 'OpenAI',
-    modalities: ['Text']
-  },
-  {
-    value: 'near/Qwen/Qwen3-30B-A3B-Instruct-2507',
-    label: 'Qwen3 30B A3B Instruct',
-    category: 'General',
-    sourceGateway: 'near',
-    developer: 'Qwen',
-    modalities: ['Text']
-  },
-];
-
-// Incognito mode default model (first model in the list)
-export const INCOGNITO_DEFAULT_MODEL: ModelOption = NEAR_INCOGNITO_MODELS[0];
-
 // Storage keys for persistence
 const INCOGNITO_STORAGE_KEY = 'gatewayz_incognito_mode';
 const PREVIOUS_MODEL_STORAGE_KEY = 'gatewayz_previous_model';
@@ -66,12 +26,6 @@ const getPreviousModel = (): ModelOption | null => {
   } catch {
     return null;
   }
-};
-
-// Helper to check if a model is a valid NEAR incognito model
-const isNearIncognitoModel = (model: ModelOption | null): boolean => {
-  if (!model) return false;
-  return model.sourceGateway === 'near' || model.value.startsWith('near/');
 };
 
 // Helper to get auto-enable search preference from localStorage
@@ -115,24 +69,11 @@ interface ChatUIState {
   setAutoEnableSearch: (enabled: boolean) => void;
 }
 
-// Standard default model — used as initial placeholder before the catalog loads.
-// ModelSelect will replace this with the best available model from the live catalog
-// (see the defaultModelSet effect in model-select.tsx).
-// Using a common OpenRouter-routed model that is broadly available.
-const STANDARD_DEFAULT_MODEL: ModelOption = {
-  value: 'anthropic/claude-sonnet-4.6',
-  label: 'Claude Sonnet 4.6',
-  category: 'General',
-  sourceGateway: 'openrouter',
-  developer: 'Anthropic',
-  modalities: ['Text', 'Image']
-};
-
 export const useChatUIStore = create<ChatUIState>((set, get) => ({
   activeSessionId: null,
   mobileSidebarOpen: false,
   inputValue: '',
-  selectedModel: getInitialIncognitoState() ? INCOGNITO_DEFAULT_MODEL : STANDARD_DEFAULT_MODEL,
+  selectedModel: null,
   messageStartTime: null,
   isIncognitoMode: getInitialIncognitoState(),
   previousModel: getPreviousModel(),
@@ -166,9 +107,9 @@ export const useChatUIStore = create<ChatUIState>((set, get) => ({
       }
     }
 
-    // If incognito mode is enabled but selected model is not a NEAR model,
-    // we need to fix the state (this happens due to SSR hydration mismatch)
-    if (storedIncognito && !isNearIncognitoModel(state.selectedModel)) {
+    // ModelSelect resolves the first live NEAR model from the catalog. Keep the
+    // store model-free during hydration so no removed provider can be selected.
+    if (storedIncognito) {
       // Read the actual previous model from localStorage (not the SSR default)
       const storedPreviousModel = getPreviousModel();
       // If no stored previous model, use current SSR model as fallback
@@ -177,7 +118,7 @@ export const useChatUIStore = create<ChatUIState>((set, get) => ({
         _hasHydrated: true,
         isIncognitoMode: true,
         previousModel: previousModel,
-        selectedModel: INCOGNITO_DEFAULT_MODEL
+        selectedModel: null
       });
 
       // Only persist to localStorage if we didn't have a stored value
@@ -222,22 +163,18 @@ export const useChatUIStore = create<ChatUIState>((set, get) => ({
 
     // Update state
     if (enabled) {
-      // Entering incognito: save current model and switch to incognito model
+      // Entering incognito: save current model. ModelSelect will choose the
+      // first live NEAR catalog entry, or leave selection empty when unavailable.
       set({
         isIncognitoMode: true,
         previousModel: currentModel,
-        selectedModel: INCOGNITO_DEFAULT_MODEL
+        selectedModel: null
       });
     } else {
       // Exiting incognito: restore previous model
-      // NOTE: If user changed the model while in incognito mode via ModelSelect,
-      // that change is intentionally not persisted because incognito mode is
-      // specifically about using GLM-4.6 for privacy. Changing the model while
-      // in incognito effectively overrides the incognito behavior for that session,
-      // but exiting still restores the pre-incognito model.
       set({
         isIncognitoMode: false,
-        selectedModel: previousModel || STANDARD_DEFAULT_MODEL
+        selectedModel: previousModel || null
       });
     }
   },


### PR DESCRIPTION
## What was done
- remove hardcoded Router, Claude, GPT, Gemini, and NEAR selections
- reconcile chat selection only against active routable catalog entries
- use the backend-compatible 100-model page size
- make modality switching and deep links catalog-driven
- prevent image prompts from injecting unavailable models

## Files changed
- `src/components/chat-v2/ChatLayout.tsx`
- `src/components/chat-v2/model-select.tsx`
- `src/lib/hooks/use-auto-model-switch.ts`
- `src/lib/store/chat-ui-store.ts`
- catalog/model service types and focused tests

## Verification
- 206 focused tests pass
- typecheck and production build pass
- lint passes with one unrelated existing footer warning